### PR TITLE
임시로 스피너 시간

### DIFF
--- a/src/app/poll/[id]/page.tsx
+++ b/src/app/poll/[id]/page.tsx
@@ -82,7 +82,10 @@ export default function PollDetailPage() {
       } catch {
         setError('투표 정보를 불러오지 못했습니다.')
       } finally {
-        setLoading(false)
+        // 3초 지연 후 로딩 완료
+        setTimeout(() => {
+          setLoading(false)
+        }, 3000)
       }
     }
     if (id) fetchDetail()
@@ -102,7 +105,10 @@ export default function PollDetailPage() {
       } catch {
         setError('댓글 정보를 불러오지 못했습니다.')
       } finally {
-        setLoading(false)
+        // 3초 지연 후 로딩 완료
+        setTimeout(() => {
+          setLoading(false)
+        }, 3000)
       }
     }
 

--- a/src/components/pages/balanse/balansePage.tsx
+++ b/src/components/pages/balanse/balansePage.tsx
@@ -74,7 +74,10 @@ function BalancePageContent() {
     } catch {
       setError('추가 데이터를 불러오지 못했습니다.')
     } finally {
-      setIsLoadingMore(false)
+      // 3초 지연 후 로딩 완료
+      setTimeout(() => {
+        setIsLoadingMore(false)
+      }, 3000)
     }
   }, [category, sort, hasNextPage, nextCursor, isLoadingMore])
 
@@ -115,7 +118,10 @@ function BalancePageContent() {
       } catch {
         setError('불러오기 실패')
       } finally {
-        setLoading(false)
+        // 3초 지연 후 로딩 완료
+        setTimeout(() => {
+          setLoading(false)
+        }, 3000)
       }
     }
     getVotes()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 로딩 상태 해제를 3초 지연하도록 변경해 일관된 로딩 경험을 제공합니다.
  - 투표 상세 페이지에서 상세 및 댓글 로딩 표시가 최소 3초 유지됩니다.
  - 밸런스 페이지에서 초기 데이터 로딩과 더보기 로딩 표시가 최소 3초 유지됩니다.
  - 에러 메시지와 기타 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->