### PR TITLE
[CHORE] 탈퇴하기 추가 / refresh

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -33,3 +33,11 @@ export const logout = async () => {
     throw error
   }
 }
+
+export const signout = async () => {
+  try {
+    await authApi.post('/auth/withdraw')
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/app/poll/[id]/page.tsx
+++ b/src/app/poll/[id]/page.tsx
@@ -259,6 +259,7 @@ export default function PollDetailPage() {
             comments={comments}
             voteId={data.voteId}
             onClose={() => setOpen(false)}
+            profile={profile}
           />
         )}
         {data && (

--- a/src/app/poll/[id]/page.tsx
+++ b/src/app/poll/[id]/page.tsx
@@ -194,7 +194,7 @@ export default function PollDetailPage() {
     try {
       await deleteVote(data.voteId)
       setDeleteModalOpen(false)
-      router.back()
+      router.push('/balanse')
     } catch (error) {
       console.error('게시글 삭제 실패:', error)
       alert('게시글 삭제에 실패했습니다.')

--- a/src/components/pages/my/accountControlSection.tsx
+++ b/src/components/pages/my/accountControlSection.tsx
@@ -1,5 +1,5 @@
 import { useAppDispatch } from '@/hooks/utils/useAppDispatch'
-import { logoutThunk } from '@/store/thunks/authThunks'
+import { logoutThunk, signoutThunk } from '@/store/thunks/authThunks'
 
 export default function AccountControlSection() {
   const dispatch = useAppDispatch()
@@ -8,14 +8,20 @@ export default function AccountControlSection() {
     dispatch(logoutThunk())
   }
 
+  const handleSignout = () => {
+    dispatch(signoutThunk())
+  }
+
   return (
     <section className="bg-white px-4 py-4 text-md">
       <div className="h-10 text-[#555555]">계정 관리</div>
       <div className="flex flex-col gap-3">
-        <div className="text-left h-10 font-bold" onClick={handleLogout}>
+        <button className="text-left h-10 font-bold" onClick={handleLogout}>
           로그아웃
-        </div>
-        <div className="text-left h-10 font-bold">탈퇴하기</div>
+        </button>
+        <button className="text-left h-10 font-bold" onClick={handleSignout}>
+          탈퇴하기
+        </button>
       </div>
     </section>
   )

--- a/src/components/pages/poll/Comment/commentDetail.tsx
+++ b/src/components/pages/poll/Comment/commentDetail.tsx
@@ -26,17 +26,20 @@ import {
   ModalBody,
   ModalFooter,
 } from '@/components/ui/modal'
+import { Profile } from '@/types/member'
 
 interface CommentDetailProps {
   comments?: Comment[]
   voteId?: number | string
   onClose?: () => void
+  profile: Profile
 }
 
 const CommentDetail = ({
   comments = [],
   voteId,
   onClose,
+  profile,
 }: CommentDetailProps) => {
   const [openReplies, setOpenReplies] = useState<Record<number, boolean>>({})
   const [currentSort, setCurrentSort] = useState<'popular' | 'latest'>(
@@ -294,12 +297,15 @@ const CommentDetail = ({
                   </div>
                 </div>
                 <div className="relative menu-container">
-                  <button
-                    className="text-gray-400 hover:text-gray-600 p-1"
-                    onClick={() => toggleMenu(comment.commentId)}
-                  >
-                    <MoreVertical size={16} />
-                  </button>
+                  {(profile.role === 'ADMIN' ||
+                    comment.nickname === profile.nickname) && (
+                    <button
+                      className="text-gray-400 hover:text-gray-600 p-1"
+                      onClick={() => toggleMenu(comment.commentId)}
+                    >
+                      <MoreVertical size={16} />
+                    </button>
+                  )}
                   {openMenus[comment.commentId] && (
                     <div className="absolute right-0 top-8 bg-white border border-gray-200 rounded-lg shadow-lg z-10 min-w-[120px]">
                       <button

--- a/src/components/pages/poll/Comment/commentDetail.tsx
+++ b/src/components/pages/poll/Comment/commentDetail.tsx
@@ -204,13 +204,12 @@ const CommentDetail = ({
 
   const confirmDelete = async () => {
     const { commentId } = deleteConfirmModal
-    if (!commentId) return
+    if (!commentId || !voteId) return
 
     try {
       await deleteComment(commentId)
-      setLocalComments((prev) =>
-        prev.filter((comment) => comment.commentId !== commentId),
-      )
+      const response = await fetchComments(voteId, { sort: currentSort })
+      setLocalComments(response.comments)
       setDeleteConfirmModal({ isOpen: false, commentId: null })
     } catch (error) {
       console.error('댓글 삭제 실패:', error)

--- a/src/store/thunks/authThunks.ts
+++ b/src/store/thunks/authThunks.ts
@@ -9,7 +9,7 @@ import { AppDispatch } from '../store'
 import { getRefreshToken } from '@/utils/tokenUtils'
 import { saveTokens, clearTokens } from '@/utils/tokenUtils'
 import { reissue } from '@/api/auth'
-import { logout as logoutApi } from '@/api/auth'
+import { logout as logoutApi, signout as signoutApi } from '@/api/auth'
 import { login } from '@/api/auth'
 
 export const loginThunk = (code: string) => async (dispatch: AppDispatch) => {
@@ -47,6 +47,16 @@ export const reissueThunk = () => async (dispatch: AppDispatch) => {
 export const logoutThunk = () => async (dispatch: AppDispatch) => {
   try {
     await logoutApi()
+    dispatch(logout())
+    clearTokens()
+  } catch (err) {
+    throw err
+  }
+}
+
+export const signoutThunk = () => async (dispatch: AppDispatch) => {
+  try {
+    await signoutApi()
     dispatch(logout())
     clearTokens()
   } catch (err) {


### PR DESCRIPTION
## 📝 요약

- 탈퇴하기 추가 / refresh

## ✅ 작업 내용

- [x] 탈퇴하기 추가
- [x] 권한이 없는 댓글에 대한 조작 UI 노출 숨김
- [x] 댓글 삭제 이후 refresh

## 🧪 테스트 방법

- 관리자 계정으로 댓글 삭제 시도하고 관리자 도구 네트워크 탭에서 commets fetch 발생하는지 확인하기

## 📷 참고 자료 (스크린샷/링크/GIF 등)

## 🔬 관련 이슈

- close #91 

## ☝️ 참고 사항

- 참고하세요~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 계정 탈퇴 기능 추가 (마이페이지 계정 관리 섹션)

* **버그 수정**
  * 댓글 관리 옵션 메뉴에 접근 제어 추가 - 관리자 및 댓글 작성자만 표시
  * 투표 삭제 후 네비게이션 동작 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->