### PR TITLE
fix: poll loading.tsx 제거로 라우트 그룹 전환 시 무한로딩 해결

### DIFF
--- a/src/app/(auth)/poll/loading.tsx
+++ b/src/app/(auth)/poll/loading.tsx
@@ -1,5 +1,0 @@
-import Loading from '@/components/_shared/loading'
-
-export default function PollLoading() {
-  return <Loading />
-}


### PR DESCRIPTION
(unauth) → (auth) 라우트 그룹 전환 시 loading.tsx의 자동 Suspense 경계가 resolve되지 않아 무한로딩 발생. 페이지 컴포넌트 자체에
Suspense와 loading 상태가 있으므로 loading.tsx 불필요

## 📝 요약

- 한 줄 요약

## ✅ 작업 내용

- [ ] 이런 일을
- [ ] 했습니다

## 🧪 테스트 방법

- ex) console.log
- ex2) .env

## 📷 참고 자료 (스크린샷/링크/GIF 등)

## 🔬 관련 이슈

- close #ISSUE_NUMBER

## ☝️ 참고 사항

- 참고하세요~