### PR TITLE
feat: 투표 리스트/상세에 작성자 호칭 노출

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_KAKAO_CLIENT_ID=your_kakao_client_id
+NEXT_PUBLIC_BASE_URL=https://valanserver.store/dev-server/
+NEXT_PUBLIC_KAKAO_REDIRECT_URI=http://localhost:3000/oauth/kakao/redirect
+NEXT_PUBLIC_KAKAO_URL=https://kauth.kakao.com/oauth/authorize

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/src/api/pages/valanse/trendingVoteApi.ts
+++ b/src/api/pages/valanse/trendingVoteApi.ts
@@ -8,6 +8,7 @@ export type TrendingVoteResponse = {
   category: string
   totalParticipants: number
   createdBy: string
+  creatorTitle: string | null
   createdAt: string
   pinType: PinType
   options: {

--- a/src/api/votes.ts
+++ b/src/api/votes.ts
@@ -29,6 +29,7 @@ export interface BestVoteResponse {
   category: VoteCategory
   totalParticipants: number
   createdBy: string
+  creatorTitle: string | null
   createdAt: string
   options: VoteOption[]
   pinType: PinType

--- a/src/app/(auth)/poll/[id]/page.tsx
+++ b/src/app/(auth)/poll/[id]/page.tsx
@@ -42,6 +42,7 @@ interface PollDetail {
   content: string | null
   category: string
   creatorNickname: string
+  creatorTitle: string | null
   createdAt: string
   totalVoteCount: number
   options: PollOption[]
@@ -237,6 +238,7 @@ function PollDetailContent() {
           <PollCard
             voteId={data.voteId}
             createdBy={data.creatorNickname}
+            creatorTitle={data.creatorTitle}
             title={data.title}
             content={data.content}
             options={data.options.map((opt) => ({

--- a/src/components/pages/balanse/balanse-list-section/balanseList.tsx
+++ b/src/components/pages/balanse/balanse-list-section/balanseList.tsx
@@ -24,6 +24,11 @@ export default function BalanceList({ data, onPinChange }: Props) {
           <CardHeader className="flex flex-row items-center justify-between gap-2 pb-0">
             <div className="flex items-center gap-2">
               <UserCircle className="text-gray-400 w-5 h-5" />
+              {data.member_title && (
+                <span className="inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-[11px] font-medium text-white">
+                  {data.member_title}
+                </span>
+              )}
               <span className="text-sm text-gray-600">
                 {data.nickname} • {data.created_at}
               </span>

--- a/src/components/pages/balanse/trending-section/mockPollCard.tsx
+++ b/src/components/pages/balanse/trending-section/mockPollCard.tsx
@@ -37,8 +37,15 @@ function MockPollCard({ data }: Props) {
         className="block mx-auto p-4 mt-6 space-y-4 rounded-xl bg-[#F0F0F0] cursor-pointer"
         onClick={handleClick}
       >
-        <div className="text-sm font-medium text-gray-700">
-          {data.createdBy}
+        <div className="flex items-center gap-2">
+          {data.creatorTitle && (
+            <span className="inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-[11px] font-medium text-white">
+              {data.creatorTitle}
+            </span>
+          )}
+          <span className="text-sm font-medium text-gray-700">
+            {data.createdBy}
+          </span>
         </div>
         <div className="flex justify-between items-center">
           <div className="text-base font-semibold">{data.title}</div>

--- a/src/components/pages/poll/pollCard.tsx
+++ b/src/components/pages/poll/pollCard.tsx
@@ -16,6 +16,7 @@ import LoginRequiredModal from '@/components/ui/modal/loginRequiredModal'
 interface PollCardProps {
   voteId: number | string
   createdBy: string
+  creatorTitle?: string | null
   title: string
   content?: string | null
   options: {
@@ -33,6 +34,7 @@ interface PollCardProps {
 function PollCard({
   voteId,
   createdBy,
+  creatorTitle,
   title,
   content,
   options = [],
@@ -171,7 +173,14 @@ function PollCard({
   return (
     <>
       <div className="mx-auto p-4 space-y-4 rounded-xl shadow bg-white mb-6">
-        <div className="text-sm font-medium text-gray-700">{createdBy}</div>
+        <div className="flex items-center gap-2">
+          {creatorTitle && (
+            <span className="inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-[11px] font-medium text-white">
+              {creatorTitle}
+            </span>
+          )}
+          <span className="text-sm font-medium text-gray-700">{createdBy}</span>
+        </div>
         <div className="text-base font-semibold">{title}</div>
         {content && (
           <div className="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap">

--- a/src/types/balanse/vote.ts
+++ b/src/types/balanse/vote.ts
@@ -10,6 +10,7 @@ export interface Vote {
   category: string
   member_id: number
   nickname: string
+  member_title: string | null
   created_at: string
   total_vote_count: number
   total_comment_count: number


### PR DESCRIPTION
## Summary
- `/votes` 리스트 응답의 `member_title`, `/votes/{id}` · `/votes/trending` · `/votes/best` 응답의 `creatorTitle`을 타입에 추가
- 닉네임 좌측에 `#4D7298` pill 배지로 호칭 표시 (`balanseList`, `mockPollCard`, `pollCard`)
- 호칭이 `null`이면 배지 자체를 숨김
- `NEXT_PUBLIC_BASE_URL`을 `https://valanserver.store/dev-server/`로 갱신하고 `.env.example` 추가 (gitignore 예외 처리)

## Test plan
- [x] `/balanse` 인기 급상승 토픽 카드에 호칭 배지 표시
- [x] `/balanse` 리스트 카드 각 항목에 호칭 배지 표시
- [x] `/poll/{id}` 상세 카드에 호칭 배지 표시
- [x] dev-server 응답 정상 200 (`member_title` / `creatorTitle` 수신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 투표 및 밸런스 카드에서 작성자의 직함 정보가 배지로 표시됩니다.
  * 인기 투표와 최고 평점 투표 목록에 작성자 직함 정보가 추가되었습니다.

* **설정 업데이트**
  * Kakao OAuth 인증을 위한 환경설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->