### PR TITLE
feat: page-view 수집 및 CMS MAU 통계 페이지

### DIFF
--- a/apps/cms/src/app/(auth)/analytics/page.tsx
+++ b/apps/cms/src/app/(auth)/analytics/page.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import axios from 'axios'
+import { Users, UserCheck, UserX, Activity } from 'lucide-react'
+import { fetchMau } from '@/lib/analytics'
+import type { MauResponse } from '@/types/analytics'
+
+const START_YEAR = 2026
+const START_MONTH = 6
+
+function getNow() {
+  const d = new Date()
+  return { year: d.getFullYear(), month: d.getMonth() + 1 }
+}
+
+function availableYears(): number[] {
+  const now = getNow()
+  const ys: number[] = []
+  for (let y = START_YEAR; y <= now.year; y++) ys.push(y)
+  return ys
+}
+
+function availableMonths(year: number): number[] {
+  const now = getNow()
+  const min = year === START_YEAR ? START_MONTH : 1
+  const max = year === now.year ? now.month : 12
+  const ms: number[] = []
+  for (let m = min; m <= max; m++) ms.push(m)
+  return ms
+}
+
+function toYearMonth(year: number, month: number) {
+  return `${year}-${String(month).padStart(2, '0')}`
+}
+
+export default function AnalyticsPage() {
+  const now = getNow()
+  const [year, setYear] = useState(now.year)
+  const [month, setMonth] = useState(now.month)
+  const [data, setData] = useState<MauResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const yearMonth = toYearMonth(year, month)
+  const isStartMonth = year === START_YEAR && month === START_MONTH
+
+  const load = useCallback(async (ym: string) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchMau(ym)
+      setData(res)
+    } catch (err) {
+      setData(null)
+      const msg = axios.isAxiosError(err)
+        ? ((err.response?.data as { error?: string; message?: string } | undefined)
+            ?.error ??
+          (err.response?.data as { error?: string; message?: string } | undefined)
+            ?.message ??
+          err.message)
+        : err instanceof Error
+          ? err.message
+          : 'MAU 데이터를 불러오지 못했습니다.'
+      setError(msg)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load(yearMonth)
+  }, [yearMonth, load])
+
+  return (
+    <div className="space-y-4">
+      <header className="flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">통계</h1>
+          <p className="text-sm text-gray-600">월별 활성 사용자(MAU) 집계입니다.</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={year}
+            onChange={(e) => {
+              const y = Number(e.target.value)
+              setYear(y)
+              const months = availableMonths(y)
+              if (!months.includes(month)) setMonth(months[months.length - 1])
+            }}
+            className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+          >
+            {availableYears().map((y) => (
+              <option key={y} value={y}>
+                {y}년
+              </option>
+            ))}
+          </select>
+          <select
+            value={month}
+            onChange={(e) => setMonth(Number(e.target.value))}
+            className="rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+          >
+            {availableMonths(year).map((m) => (
+              <option key={m} value={m}>
+                {m}월
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      {isStartMonth && (
+        <p className="rounded-md bg-amber-50 px-3 py-2 text-xs text-amber-800">
+          2026년 6월 중에 집계를 시작했기 때문에 해당 월의 데이터는 정확하지 않을 수 있습니다.
+        </p>
+      )}
+
+      {error && (
+        <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>
+      )}
+
+      <section className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="총 MAU"
+          value={data?.totalMau}
+          loading={loading}
+          icon={<Activity className="h-4 w-4 text-gray-700" />}
+          accent="bg-gray-50 border-gray-200"
+        />
+        <StatCard
+          label="로그인 사용자"
+          value={data?.loginMau}
+          loading={loading}
+          icon={<UserCheck className="h-4 w-4 text-blue-600" />}
+          accent="bg-blue-50 border-blue-200"
+        />
+        <StatCard
+          label="비로그인 사용자"
+          value={data?.anonymousMau}
+          loading={loading}
+          icon={<Users className="h-4 w-4 text-emerald-600" />}
+          accent="bg-emerald-50 border-emerald-200"
+        />
+        <StatCard
+          label="탈퇴한 사용자"
+          value={data?.withdrawnMau}
+          loading={loading}
+          icon={<UserX className="h-4 w-4 text-rose-600" />}
+          accent="bg-rose-50 border-rose-200"
+        />
+      </section>
+
+      {data && (
+        <p className="text-xs text-gray-500">집계 기준: {data.yearMonth}</p>
+      )}
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  loading,
+  icon,
+  accent,
+}: {
+  label: string
+  value?: number
+  loading: boolean
+  icon: React.ReactNode
+  accent: string
+}) {
+  return (
+    <div className={`rounded-lg border p-4 ${accent}`}>
+      <div className="flex items-center gap-1.5 text-xs font-medium text-gray-700">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-2 text-2xl font-semibold text-gray-900">
+        {loading ? '...' : (value ?? 0).toLocaleString()}
+      </p>
+    </div>
+  )
+}

--- a/apps/cms/src/app/(auth)/layout.tsx
+++ b/apps/cms/src/app/(auth)/layout.tsx
@@ -10,6 +10,7 @@ const NAV = [
   { href: '/admin', label: '대시보드' },
   { href: '/votes', label: '투표 관리' },
   { href: '/titles', label: '칭호 관리' },
+  { href: '/analytics', label: '통계' },
 ]
 
 export default function AuthedLayout({

--- a/apps/cms/src/lib/analytics.ts
+++ b/apps/cms/src/lib/analytics.ts
@@ -1,0 +1,9 @@
+import { api } from './api'
+import type { MauResponse } from '@/types/analytics'
+
+export async function fetchMau(yearMonth: string): Promise<MauResponse> {
+  const res = await api.get<MauResponse>('/admin/analytics/mau', {
+    params: { yearMonth },
+  })
+  return res.data
+}

--- a/apps/cms/src/types/analytics.ts
+++ b/apps/cms/src/types/analytics.ts
@@ -1,0 +1,7 @@
+export interface MauResponse {
+  yearMonth: string
+  anonymousMau: number
+  loginMau: number
+  withdrawnMau: number
+  totalMau: number
+}

--- a/apps/web/src/api/analytics.ts
+++ b/apps/web/src/api/analytics.ts
@@ -1,0 +1,22 @@
+import { publicApi } from './instance/publicApi'
+import { getAccessToken } from '@/utils/tokenUtils'
+
+export interface PageViewPayload {
+  anonymousId: string
+  pagePath: string
+}
+
+export interface PageViewResponse {
+  eventId: number
+}
+
+export async function postPageView(payload: PageViewPayload): Promise<PageViewResponse> {
+  const token = getAccessToken()
+  const config = token ? { headers: { Authorization: `Bearer ${token}` } } : undefined
+  const res = await publicApi.post<PageViewResponse>(
+    '/analytics/events/page-view',
+    payload,
+    config,
+  )
+  return res.data
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css'
 import Providers from './providers'
 import { ModalRootInitializer } from './modalRootInitializer'
 import { NativeBackHandler } from '@/components/_shared/nativeBackHandler'
+import { PageViewTracker } from '@/components/_shared/pageViewTracker'
 
 const SITE_URL = 'https://valanse.kr'
 const SITE_NAME = 'ValanSe'
@@ -108,6 +109,7 @@ export default function RootLayout({
         <Providers>
           <ModalRootInitializer />
           <NativeBackHandler />
+          <PageViewTracker />
           {children}
         </Providers>
       </body>

--- a/apps/web/src/components/_shared/pageViewTracker.tsx
+++ b/apps/web/src/components/_shared/pageViewTracker.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { usePathname } from 'next/navigation'
+import { postPageView } from '@/api/analytics'
+import { getOrCreateAnonymousId } from '@/utils/anonymousId'
+
+const ENABLED = process.env.NODE_ENV === 'production'
+
+export function PageViewTracker() {
+  const pathname = usePathname()
+  const lastSentRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!ENABLED) return
+    if (!pathname) return
+    if (lastSentRef.current === pathname) return
+    lastSentRef.current = pathname
+
+    const anonymousId = getOrCreateAnonymousId()
+    if (!anonymousId) return
+
+    postPageView({ anonymousId, pagePath: pathname }).catch(() => {})
+  }, [pathname])
+
+  return null
+}

--- a/apps/web/src/utils/anonymousId.ts
+++ b/apps/web/src/utils/anonymousId.ts
@@ -1,0 +1,22 @@
+const STORAGE_KEY = 'valanse_anonymous_id'
+
+function generate(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return `anon-${crypto.randomUUID()}`
+  }
+  // 폴백: timestamp + random
+  return `anon-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export function getOrCreateAnonymousId(): string | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const existing = window.localStorage.getItem(STORAGE_KEY)
+    if (existing) return existing
+    const fresh = generate()
+    window.localStorage.setItem(STORAGE_KEY, fresh)
+    return fresh
+  } catch {
+    return null
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "dev": "pnpm -r --parallel --stream dev",
     "dev:web": "pnpm --filter valanse-web dev",
     "dev:cms": "pnpm --filter valanse-cms dev",
     "build": "pnpm -r build",


### PR DESCRIPTION
## Summary
- **web**: 라우트 변경마다 `POST /analytics/events/page-view` 호출
  - `anonymousId` UUID는 `localStorage('valanse_anonymous_id')` 저장
  - 로그인 상태면 access token 같이 전송
  - `NODE_ENV === 'production'` 일 때만 활성 (로컬 `pnpm dev` 제외)
- **cms**: `/analytics` 페이지 신설
  - `GET /admin/analytics/mau?yearMonth=YYYY-MM`
  - 연/월 select (시작 2026-06)
  - 총/로그인/비로그인/탈퇴 MAU 4개 카드
  - 시작월(2026-06) 안내 메시지
- LNB에 '통계' 메뉴 추가
- 루트 `pnpm dev` 추가 (web 3000 + cms 3001 병렬 실행)

## Test plan
- [ ] 로컬 `pnpm dev` → web/cms 동시 기동, 네트워크 탭에 `/analytics/events/page-view` 호출 **없음**
- [ ] Vercel 배포(prod/preview)에서 web 페이지 진입/이동 시 호출 발생, `anonymousId` 동일 유지
- [ ] 로그인 상태에선 Authorization 헤더 동봉, 비로그인이면 헤더 없이 전송
- [ ] CMS `/analytics` 진입 시 현재 월 자동 조회, 연/월 변경 시 재조회
- [ ] 2026-06 선택 시 노란 안내 박스 노출
- [ ] 응답 4개 값이 카드에 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 화면에 월별 활성 사용자( MAU ) 통계 페이지와 메뉴를 추가했습니다.
  * 웹 앱에서 페이지 방문 기록이 자동으로 수집되도록 했습니다.
* **개선**
  * 통계 페이지에서 월 선택, 로딩 표시, 오류 안내, 데이터 경고 문구를 제공해 상태를 더 명확히 확인할 수 있습니다.
  * 통계는 총합, 로그인, 비로그인, 탈퇴 기준으로 나뉘어 표시됩니다.
* **기타**
  * 개발 실행 방식이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->