### PR TITLE
feat(header,tab): Figma 신규 사양 반영 Header + TabBar 신설

### DIFF
--- a/apps/web/src/components/common/Header.stories.tsx
+++ b/apps/web/src/components/common/Header.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Header, HeaderBackButton, HeaderMoreButton } from './Header'
+
+const meta = {
+  title: 'Common/Header',
+  component: Header,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Figma `6315:6803` 기반. size(xl/s) × leading(back/none) × trailing(more/none) 조합. xl은 Heading-04, s는 Heading-06.',
+      },
+    },
+  },
+  args: {
+    title: '밸런스게임',
+  },
+  argTypes: {
+    size: { control: 'radio', options: ['xl', 's'] },
+  },
+} satisfies Meta<typeof Header>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const XL: Story = { args: { size: 'xl' } }
+
+export const Small: Story = { args: { size: 's' } }
+
+export const WithBack: Story = {
+  args: {
+    size: 'xl',
+    leading: <HeaderBackButton />,
+  },
+}
+
+export const WithBackAndMore: Story = {
+  args: {
+    size: 'xl',
+    leading: <HeaderBackButton />,
+    trailing: <HeaderMoreButton />,
+  },
+}
+
+export const SmallWithMore: Story = {
+  args: {
+    size: 's',
+    trailing: <HeaderMoreButton />,
+  },
+}
+
+/** 모든 조합 매트릭스 */
+export const Matrix: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4">
+      <Header size="xl" title="XL · 기본" />
+      <Header size="xl" title="XL · 뒤로가기" leading={<HeaderBackButton />} />
+      <Header
+        size="xl"
+        title="XL · 뒤로 + 더보기"
+        leading={<HeaderBackButton />}
+        trailing={<HeaderMoreButton />}
+      />
+      <Header size="s" title="S · 기본" />
+      <Header size="s" title="S · 뒤로가기" leading={<HeaderBackButton />} />
+      <Header
+        size="s"
+        title="S · 뒤로 + 더보기"
+        leading={<HeaderBackButton />}
+        trailing={<HeaderMoreButton />}
+      />
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/Header.tsx
+++ b/apps/web/src/components/common/Header.tsx
@@ -1,0 +1,7 @@
+export {
+  Header,
+  HeaderBackButton,
+  HeaderMoreButton,
+  headerVariants,
+  type HeaderProps,
+} from '@/components/ui/header'

--- a/apps/web/src/components/common/TabBar.stories.tsx
+++ b/apps/web/src/components/common/TabBar.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { useState } from 'react'
+import { TabBar, TabItem } from './TabBar'
+
+const meta = {
+  title: 'Common/TabBar',
+  component: TabBar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Figma `6321:7510` 기반. selected/false 두 상태. active는 V300 밑줄+텍스트, inactive는 G75. 접근성: role=tablist / tab, aria-selected.',
+      },
+    },
+  },
+} satisfies Meta<typeof TabBar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const TABS = ['전체', '음식', '연애', '기타'] as const
+
+export const Default: Story = {
+  render: () => (
+    <TabBar>
+      {TABS.map((label, i) => (
+        <TabItem key={label} label={label} selected={i === 0} />
+      ))}
+    </TabBar>
+  ),
+}
+
+/** 클릭으로 상태 전환 확인용 인터랙티브 스토리 */
+export const Interactive: Story = {
+  render: () => {
+    const [active, setActive] = useState(0)
+    return (
+      <TabBar>
+        {TABS.map((label, i) => (
+          <TabItem
+            key={label}
+            label={label}
+            selected={active === i}
+            onClick={() => setActive(i)}
+          />
+        ))}
+      </TabBar>
+    )
+  },
+}
+
+/** 각 탭이 선택됐을 때 시각 확인용 매트릭스 */
+export const AllSelectedStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {TABS.map((selectedLabel, sel) => (
+        <TabBar key={selectedLabel}>
+          {TABS.map((label, i) => (
+            <TabItem key={label} label={label} selected={i === sel} />
+          ))}
+        </TabBar>
+      ))}
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/TabBar.tsx
+++ b/apps/web/src/components/common/TabBar.tsx
@@ -1,0 +1,6 @@
+export {
+  TabBar,
+  TabItem,
+  type TabBarProps,
+  type TabItemProps,
+} from '@/components/ui/tabs'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,2 @@
+export * from './Header'
+export * from './TabBar'

--- a/apps/web/src/components/ui/header.tsx
+++ b/apps/web/src/components/ui/header.tsx
@@ -1,0 +1,123 @@
+/* eslint-disable react/prop-types */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const headerVariants = cva(
+  'flex items-center justify-between w-full h-14 px-6 bg-card text-foreground',
+  {
+    variants: {
+      size: {
+        xl: '',
+        s: '',
+      },
+    },
+    defaultVariants: { size: 'xl' },
+  },
+)
+
+const headerTitleVariants = cva('flex-1', {
+  variants: {
+    size: {
+      xl: 'typo-heading-04',
+      s: 'typo-heading-06',
+    },
+  },
+  defaultVariants: { size: 'xl' },
+})
+
+export interface HeaderProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'title'>,
+    VariantProps<typeof headerVariants> {
+  title: React.ReactNode
+  leading?: React.ReactNode
+  trailing?: React.ReactNode
+}
+
+const Header = React.forwardRef<HTMLElement, HeaderProps>(
+  ({ className, size, title, leading, trailing, ...props }, ref) => (
+    <header
+      ref={ref}
+      className={cn(headerVariants({ size }), className)}
+      {...props}
+    >
+      {leading ? (
+        <div className="flex items-center">{leading}</div>
+      ) : (
+        <div aria-hidden="true" className="w-6" />
+      )}
+      <h1 className={headerTitleVariants({ size })}>{title}</h1>
+      {trailing ? (
+        <div className="flex items-center">{trailing}</div>
+      ) : (
+        <div aria-hidden="true" className="w-6" />
+      )}
+    </header>
+  ),
+)
+Header.displayName = 'Header'
+
+/** 헤더 우측의 "더보기" 텍스트 버튼. Figma text button 컴포넌트 대응. */
+const HeaderMoreButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ className, children = '더보기', ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className={cn(
+      'inline-flex items-center gap-1 typo-label-02 text-brand-gray-200 hover:text-foreground transition-colors',
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M7.5 5L12.5 10L7.5 15"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  </button>
+))
+HeaderMoreButton.displayName = 'HeaderMoreButton'
+
+/** 헤더 좌측의 뒤로가기 버튼. */
+const HeaderBackButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    aria-label="뒤로가기"
+    className={cn(
+      'inline-flex h-6 w-6 items-center justify-center text-foreground',
+      className,
+    )}
+    {...props}
+  >
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M15 19l-7-7 7-7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  </button>
+))
+HeaderBackButton.displayName = 'HeaderBackButton'
+
+export { Header, HeaderBackButton, HeaderMoreButton, headerVariants }

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable react/prop-types */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+type TabBarProps = React.HTMLAttributes<HTMLDivElement>
+
+const TabBar = React.forwardRef<HTMLDivElement, TabBarProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="tablist"
+      className={cn(
+        'flex w-full items-stretch border-b border-border bg-card',
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+TabBar.displayName = 'TabBar'
+
+interface TabItemProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  selected?: boolean
+  label: React.ReactNode
+}
+
+const TabItem = React.forwardRef<HTMLButtonElement, TabItemProps>(
+  ({ className, selected, label, type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      role="tab"
+      aria-selected={selected}
+      className={cn(
+        'flex flex-1 items-center justify-center gap-2 px-1 pb-2 pt-3 text-base font-semibold transition-colors',
+        selected
+          ? '-mb-px border-b border-primary text-primary'
+          : 'text-brand-gray-75 hover:text-foreground',
+        className,
+      )}
+      {...props}
+    >
+      {label}
+    </button>
+  ),
+)
+TabItem.displayName = 'TabItem'
+
+export { TabBar, TabItem }
+export type { TabBarProps, TabItemProps }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P2** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

### Header (\`ui/header.tsx\`)

Figma [\`6315:6803\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6315-6803) 기반. CVA.

- **size**: \`xl\` (Heading-04 20/700) / \`s\` (Heading-06 16/700)
- **슬롯**: \`leading\` · \`trailing\` (양쪽 대칭 spacer로 title 중앙 정렬)
- **서브 컴포넌트**: \`HeaderBackButton\` (뒤로가기 24px), \`HeaderMoreButton\` ("더보기" Label-02 · Gray G200 · icon-park-outline:right)

### Tab (\`ui/tabs.tsx\`)

Figma [\`6321:7510\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6321-7510) 기반.

- **TabBar** — \`role=tablist\`, 하단 border
- **TabItem** — \`selected\` prop. active는 V300 밑줄+텍스트, inactive는 G75. \`aria-selected\` 접근성

### common/ 재수출 · Storybook

- \`common/Header.tsx\`, \`common/TabBar.tsx\` 재수출
- \`common/index.ts\` barrel
- \`Common/Header\` 스토리 (XL/Small/WithBack/WithBackAndMore/SmallWithMore/Matrix)
- \`Common/TabBar\` 스토리 (Default/Interactive/AllSelectedStates)

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 237 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/Header → Matrix\` 6조합 렌더 확인
- [ ] Storybook \`Common/TabBar → Interactive\` 클릭 시 active state 전환 확인

## Migration Policy

기존 \`_shared/header.tsx\`는 **legacy로 유지**. 페이지들이 여전히 여기서 import 중이므로 breaking change 방지. 실제 페이지 이관은 **P8**에서 도메인별로.

## Notes

- Tab 폰트는 Figma SF Pro Label-01 (590/16). Pretendard 대응으로 \`text-base font-semibold\` 인라인 유틸 사용 (\`.typo-*\` 스케일에 semibold 16 없음). 필요 시 후속 PR에서 typo 토큰 확장.
- \`_shared/header.tsx\`는 P8 페이지 마이그레이션 완료 후 삭제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)