### PR TITLE
feat(textfield): Figma 신규 사양 반영 TextField 신설

### DIFF
--- a/apps/web/src/components/common/TextField.stories.tsx
+++ b/apps/web/src/components/common/TextField.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { useState } from 'react'
+import { TextField } from './TextField'
+
+const meta = {
+  title: 'Common/TextField',
+  component: TextField,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Figma `6280:8355` 기반. state: default / focus (자동, `:focus-within`) / filled (자동, 값 존재) / disabled / error. label · supportText · counter · trailing 슬롯.',
+      },
+    },
+  },
+  args: {
+    label: '필드레이블',
+    placeholder: '텍스트 입력',
+    supportText: '서포트 텍스트를 입력합니다',
+  },
+} satisfies Meta<typeof TextField>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Focused: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`:focus-within` 스타일로 자동 처리. 스토리에서 input을 클릭하면 border가 V200으로 변경.',
+      },
+    },
+  },
+}
+
+export const Filled: Story = {
+  args: { defaultValue: '입력된 텍스트' },
+}
+
+export const Disabled: Story = {
+  args: { disabled: true, defaultValue: '입력 불가' },
+}
+
+export const ErrorState: Story = {
+  args: {
+    error: true,
+    defaultValue: '잘못된 값',
+    supportText: '올바른 형식이 아닙니다',
+  },
+}
+
+export const WithCounter: Story = {
+  render: (args) => {
+    const [value, setValue] = useState('')
+    return (
+      <TextField
+        {...args}
+        value={value}
+        onValueChange={setValue}
+        showCounter
+        maxLength={16}
+      />
+    )
+  },
+}
+
+export const WithoutLabel: Story = {
+  args: { label: undefined },
+}
+
+export const WithoutSupport: Story = {
+  args: { supportText: undefined },
+}
+
+/** 5 상태 매트릭스 */
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4">
+      <TextField
+        label="default"
+        placeholder="텍스트 입력"
+        supportText="서포트 텍스트"
+      />
+      <TextField
+        label="filled"
+        defaultValue="입력된 텍스트"
+        supportText="서포트 텍스트"
+      />
+      <TextField
+        label="disabled"
+        defaultValue="입력 불가"
+        disabled
+        supportText="서포트 텍스트"
+      />
+      <TextField
+        label="error"
+        defaultValue="잘못된 값"
+        error
+        supportText="올바른 형식이 아닙니다"
+      />
+      <TextField
+        label="counter (16)"
+        placeholder="텍스트 입력"
+        supportText="최대 16자"
+        showCounter
+        maxLength={16}
+      />
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/TextField.tsx
+++ b/apps/web/src/components/common/TextField.tsx
@@ -1,0 +1,5 @@
+export {
+  TextField,
+  fieldWrapperVariants,
+  type TextFieldProps,
+} from '@/components/ui/textField'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export * from './TextField'

--- a/apps/web/src/components/ui/textField.tsx
+++ b/apps/web/src/components/ui/textField.tsx
@@ -1,0 +1,180 @@
+/* eslint-disable react/prop-types */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const fieldWrapperVariants = cva(
+  'flex w-full items-center gap-2 rounded-xl border px-4 py-3 transition-colors',
+  {
+    variants: {
+      state: {
+        default:
+          'bg-card border-brand-gray-75 focus-within:border-brand-violet-200',
+        disabled: 'bg-brand-gray-50 border-transparent cursor-not-allowed',
+        error: 'bg-card border-destructive',
+      },
+    },
+    defaultVariants: { state: 'default' },
+  },
+)
+
+const inputVariants = cva(
+  'flex-1 bg-transparent outline-none typo-label-03 placeholder:text-brand-gray-100 disabled:cursor-not-allowed',
+  {
+    variants: {
+      state: {
+        default: 'text-foreground caret-primary',
+        disabled: 'text-brand-gray-75',
+        error: 'text-foreground caret-destructive',
+      },
+    },
+    defaultVariants: { state: 'default' },
+  },
+)
+
+const supportVariants = cva('typo-body-c-03', {
+  variants: {
+    state: {
+      default: 'text-brand-gray-100',
+      disabled: 'text-brand-gray-100',
+      error: 'text-destructive',
+    },
+  },
+  defaultVariants: { state: 'default' },
+})
+
+type TextFieldState = NonNullable<
+  VariantProps<typeof fieldWrapperVariants>['state']
+>
+
+export interface TextFieldProps
+  extends Omit<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    'size' | 'onChange'
+  > {
+  /** 필드 상단 레이블 텍스트. 없으면 미표시. */
+  label?: React.ReactNode
+  /** 헬프 영역 서포트/에러 메시지 */
+  supportText?: React.ReactNode
+  /** true 시 error state 강제. supportText 색상도 error로 렌더. */
+  error?: boolean
+  /** 카운터 표시. maxLength 필요. */
+  showCounter?: boolean
+  /** input 우측에 렌더할 커스텀 요소 (에러 아이콘 등 override) */
+  trailing?: React.ReactNode
+  value?: string
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onValueChange?: (value: string) => void
+}
+
+const generateId = () => `textfield-${Math.random().toString(36).slice(2, 10)}`
+
+const TextField = React.forwardRef<HTMLInputElement, TextFieldProps>(
+  (
+    {
+      className,
+      label,
+      supportText,
+      error = false,
+      showCounter = false,
+      maxLength,
+      trailing,
+      disabled,
+      value,
+      onChange,
+      onValueChange,
+      id: idProp,
+      ...props
+    },
+    ref,
+  ) => {
+    const reactId = React.useId()
+    const id = idProp ?? `${reactId}-${generateId()}`
+    const supportId = supportText ? `${id}-help` : undefined
+
+    const state: TextFieldState = disabled
+      ? 'disabled'
+      : error
+        ? 'error'
+        : 'default'
+
+    const charCount = typeof value === 'string' ? value.length : 0
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      onChange?.(e)
+      onValueChange?.(e.target.value)
+    }
+
+    return (
+      <div className={cn('flex w-full flex-col gap-2', className)}>
+        {label && (
+          <label htmlFor={id} className="typo-title-02 text-foreground">
+            {label}
+          </label>
+        )}
+        <div className="flex flex-col gap-1">
+          <div className={fieldWrapperVariants({ state })}>
+            <input
+              ref={ref}
+              id={id}
+              className={inputVariants({ state })}
+              disabled={disabled}
+              maxLength={maxLength}
+              value={value}
+              onChange={handleChange}
+              aria-invalid={error || undefined}
+              aria-describedby={supportId}
+              {...props}
+            />
+            {trailing ? (
+              trailing
+            ) : state === 'error' ? (
+              <ErrorIcon aria-hidden="true" />
+            ) : null}
+          </div>
+          {(supportText || showCounter) && (
+            <div className="flex items-center justify-end gap-2">
+              {supportText && (
+                <span
+                  id={supportId}
+                  className={cn(supportVariants({ state }), 'flex-1 text-left')}
+                >
+                  {supportText}
+                </span>
+              )}
+              {showCounter && (
+                <span className="typo-body-c-03 text-brand-gray-100 shrink-0">
+                  ({charCount}/{maxLength ?? '∞'})
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  },
+)
+TextField.displayName = 'TextField'
+
+const ErrorIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    className="shrink-0 text-destructive"
+    {...props}
+  >
+    <circle cx="9" cy="9" r="7.5" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M9 5v4.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle cx="9" cy="12.5" r="0.9" fill="currentColor" />
+  </svg>
+)
+
+export { TextField, fieldWrapperVariants }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P3** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

Figma [\`6280:8355\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6280-8355) "텍스트필드" 기반. CVA로 state 관리.

### 상태 매핑

Figma 5 states → 코드 3 state (focus/filled는 CSS 자동):

| Figma | 코드 처리 |
|---|---|
| default | \`state="default"\` |
| **focus** | 자동 (\`:focus-within\` → border V200, caret V300) |
| **filled** | 자동 (value 존재 시 텍스트 색 Black) |
| disabled | \`state="disabled"\` (bg G50, border 없음) |
| error | \`state="error"\` (border R300, 우측 에러 아이콘, support 빨강) |

### 컴포넌트 스펙

- **wrapper**: rounded-xl, padding 12px 16px, gap 8
- **label**: \`typo-title-02\` (Title-02 · 17/600)
- **input**: \`typo-label-03\` (Label-02 대응 · 14/500)
- **placeholder**: G100
- **supportText / counter**: \`typo-body-c-03\` (Body C-02 · 12/400)
- **error 아이콘**: 인라인 SVG 18×18 currentColor
- **접근성**: \`<label htmlFor>\`, \`aria-invalid\`, \`aria-describedby\`

### API

\`\`\`tsx
<TextField
  label="필드레이블"
  placeholder="텍스트 입력"
  supportText="서포트 텍스트를 입력합니다"
  showCounter maxLength={16}
  error={hasError}
  value={value}
  onValueChange={setValue}
/>
\`\`\`

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 237 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/TextField → AllStates\` 5개 렌더 확인
- [ ] Storybook \`Common/TextField → WithCounter\` 입력 시 카운터 증감

## Notes

- \`onValueChange\` prop 편의로 추가 (raw \`onChange\`도 병용 가능)
- \`filled\` 상태 별도 variant 대신 값 유무로 자동 판별 → 사용성 단순화
- 페이지 컴포넌트에서 실제 폼 교체는 **P8**에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)