### PR TITLE
feat(chip,badge): Figma 신규 사양 반영 Chip + Badge 신설

### DIFF
--- a/apps/web/src/components/common/Badge.stories.tsx
+++ b/apps/web/src/components/common/Badge.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Badge } from './Badge'
+
+const meta = {
+  title: 'Common/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Figma `6339:8861` 기반. size(s/l) × status(filled/outlined/weak/ghost) × color(purple/yellow/gray). Chip과 동일 구조이나 인터랙션 없음.',
+      },
+    },
+  },
+  args: { children: 'label' },
+  argTypes: {
+    size: { control: 'radio', options: ['s', 'l'] },
+    status: { control: 'select', options: ['filled', 'outlined', 'weak', 'ghost'] },
+    color: { control: 'radio', options: ['purple', 'yellow', 'gray'] },
+  },
+} satisfies Meta<typeof Badge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithIcon: Story = {
+  args: { icon: '🩷', children: 'HOT' },
+}
+
+/** 색상별 매트릭스 */
+export const Matrix: Story = {
+  render: () => {
+    const colors = ['purple', 'yellow', 'gray'] as const
+    const statuses = ['filled', 'outlined', 'weak', 'ghost'] as const
+    return (
+      <div className="p-4">
+        <table className="border-separate border-spacing-3">
+          <thead>
+            <tr>
+              <th className="typo-label-01 text-brand-gray-200">color \ status</th>
+              {statuses.map((s) => (
+                <th key={s} className="typo-label-01 text-brand-gray-200">
+                  {s}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {colors.map((color) => (
+              <tr key={color}>
+                <td className="typo-label-01 text-brand-gray-200 pr-2">{color}</td>
+                {statuses.map((status) => (
+                  <td key={status}>
+                    <Badge size="l" color={color} status={status}>
+                      label
+                    </Badge>
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  },
+}
+
+export const HotIndicator: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2 p-4">
+      <Badge size="s" color="purple" status="filled">
+        HOT
+      </Badge>
+      <Badge size="s" color="yellow" status="filled">
+        NEW
+      </Badge>
+      <Badge size="s" color="gray" status="weak">
+        완료
+      </Badge>
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/Badge.tsx
+++ b/apps/web/src/components/common/Badge.tsx
@@ -1,0 +1,1 @@
+export { Badge, badgeVariants, type BadgeProps } from '@/components/ui/badge'

--- a/apps/web/src/components/common/Chip.stories.tsx
+++ b/apps/web/src/components/common/Chip.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { Chip } from './Chip'
+
+const meta = {
+  title: 'Common/Chip',
+  component: Chip,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Figma `6288:5807` 기반. size(s/l) × status(primary/secondary/outline/ghost/disabled/unselected). icon 슬롯.',
+      },
+    },
+  },
+  args: { children: 'label' },
+  argTypes: {
+    size: { control: 'radio', options: ['s', 'l'] },
+    status: {
+      control: 'select',
+      options: ['primary', 'secondary', 'outline', 'ghost', 'disabled', 'unselected'],
+    },
+  },
+} satisfies Meta<typeof Chip>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const WithIcon: Story = {
+  args: { icon: '🩷', children: 'label' },
+}
+
+/** 모든 status × size 매트릭스 */
+export const Matrix: Story = {
+  render: () => {
+    const statuses = [
+      'primary',
+      'secondary',
+      'outline',
+      'ghost',
+      'disabled',
+      'unselected',
+    ] as const
+    return (
+      <div className="p-4">
+        <table className="border-separate border-spacing-3">
+          <thead>
+            <tr>
+              <th className="typo-label-01 text-brand-gray-200">status \ size</th>
+              <th className="typo-label-01 text-brand-gray-200">S</th>
+              <th className="typo-label-01 text-brand-gray-200">L</th>
+            </tr>
+          </thead>
+          <tbody>
+            {statuses.map((status) => (
+              <tr key={status}>
+                <td className="typo-label-01 text-brand-gray-200 pr-2">
+                  {status}
+                </td>
+                <td>
+                  <Chip size="s" status={status}>
+                    label
+                  </Chip>
+                </td>
+                <td>
+                  <Chip size="l" status={status}>
+                    label
+                  </Chip>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  },
+}
+
+export const CategoryFilter: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2 p-4">
+      <Chip size="l" status="primary">
+        전체
+      </Chip>
+      <Chip size="l" status="ghost">
+        음식
+      </Chip>
+      <Chip size="l" status="ghost">
+        연애
+      </Chip>
+      <Chip size="l" status="ghost">
+        기타
+      </Chip>
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/Chip.tsx
+++ b/apps/web/src/components/common/Chip.tsx
@@ -1,0 +1,1 @@
+export { Chip, chipVariants, type ChipProps } from '@/components/ui/chip'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,2 @@
+export * from './Chip'
+export * from './Badge'

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable react/prop-types */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const badgeVariants = cva('inline-flex items-center gap-1 whitespace-nowrap', {
+  variants: {
+    size: {
+      s: 'rounded-xl px-2 py-1 typo-body-c-03',
+      l: 'rounded-[15px] px-2.5 py-1.5 typo-label-03',
+    },
+    status: {
+      filled: '',
+      outlined: 'border',
+      weak: '',
+      ghost: '',
+    },
+    color: {
+      purple: '',
+      yellow: '',
+      gray: '',
+    },
+  },
+  compoundVariants: [
+    // purple
+    { color: 'purple', status: 'filled', className: 'bg-brand-violet-200 text-white' },
+    {
+      color: 'purple',
+      status: 'outlined',
+      className: 'bg-brand-violet-50 text-primary border-primary',
+    },
+    { color: 'purple', status: 'weak', className: 'bg-brand-violet-50 text-primary' },
+    { color: 'purple', status: 'ghost', className: 'bg-transparent text-primary' },
+    // yellow
+    {
+      color: 'yellow',
+      status: 'filled',
+      className: 'bg-brand-yellow-300 text-brand-gray-400',
+    },
+    {
+      color: 'yellow',
+      status: 'outlined',
+      className: 'bg-brand-yellow-50 text-brand-gray-500 border-brand-yellow-300',
+    },
+    {
+      color: 'yellow',
+      status: 'weak',
+      className: 'bg-brand-yellow-75 text-brand-gray-500',
+    },
+    // gray
+    {
+      color: 'gray',
+      status: 'outlined',
+      className: 'bg-brand-gray-50 text-foreground border-brand-gray-75',
+    },
+    { color: 'gray', status: 'weak', className: 'bg-brand-gray-50 text-foreground' },
+    { color: 'gray', status: 'ghost', className: 'bg-card text-foreground' },
+  ],
+  defaultVariants: { size: 'l', status: 'filled', color: 'purple' },
+})
+
+export interface BadgeProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'>,
+    VariantProps<typeof badgeVariants> {
+  /** 앞쪽 아이콘/이모지 슬롯 */
+  icon?: React.ReactNode
+}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, size, status, color, icon, children, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(badgeVariants({ size, status, color }), className)}
+      {...props}
+    >
+      {icon}
+      {children}
+    </span>
+  ),
+)
+Badge.displayName = 'Badge'
+
+export { Badge, badgeVariants }

--- a/apps/web/src/components/ui/chip.tsx
+++ b/apps/web/src/components/ui/chip.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable react/prop-types */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const chipVariants = cva('inline-flex items-center gap-1 whitespace-nowrap', {
+  variants: {
+    size: {
+      s: 'rounded-xl px-2 py-1 typo-body-c-03', // 4px 8px · 12px radius
+      l: 'rounded-[15px] px-2.5 py-1.5 typo-label-03', // 6px 10px · 15px radius
+    },
+    status: {
+      primary: 'bg-brand-violet-200 text-white',
+      secondary: 'bg-brand-violet-50 text-primary',
+      outline: 'border border-brand-violet-100 bg-card text-primary',
+      ghost: 'bg-card text-primary',
+      disabled:
+        'border border-brand-gray-75 bg-brand-gray-50 text-brand-gray-75 cursor-not-allowed',
+      unselected:
+        'border border-brand-gray-75 bg-card text-brand-gray-200',
+    },
+  },
+  defaultVariants: { size: 'l', status: 'primary' },
+})
+
+export interface ChipProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof chipVariants> {
+  /** 앞쪽 아이콘/이모지 슬롯 */
+  icon?: React.ReactNode
+}
+
+const Chip = React.forwardRef<HTMLSpanElement, ChipProps>(
+  ({ className, size, status, icon, children, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(chipVariants({ size, status }), className)}
+      {...props}
+    >
+      {icon}
+      {children}
+    </span>
+  ),
+)
+Chip.displayName = 'Chip'
+
+export { Chip, chipVariants }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P4** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

### Chip — Figma [\`6288:5807\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6288-5807)

CVA · 12 variants (size × status)

| status | fill | text | border |
|---|---|---|---|
| primary | V200 | white | — |
| secondary | V50 | V300(primary) | — |
| outline | card | V300 | V100 |
| ghost | card | V300 | — |
| disabled | G50 | G75 | G75 |
| unselected | card | G200 | G75 |

- size s: radius 12, padding 4px 8px, typo-body-c-03
- size l: radius 15, padding 6px 10px, typo-label-03

### Badge — Figma [\`6339:8861\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6339-8861)

CVA + \`compoundVariants\`. size × status(filled/outlined/weak/ghost) × color(purple/yellow/gray).

Figma에 존재하지 않는 조합(예: filled gray, ghost yellow)은 compoundVariant에서 스킵 → 사용 시 기본 style만 적용.

**\`BadgeProps\`는 \`Omit<HTMLAttributes, 'color'>\`** — HTMLAttributes.color(deprecated legacy attr)와 CVA color prop 충돌 회피.

### common/ 재수출

- \`common/Chip.tsx\`, \`common/Badge.tsx\`
- \`common/index.ts\` barrel
- Storybook \`Common/Chip\` (Default/WithIcon/Matrix/CategoryFilter)
- Storybook \`Common/Badge\` (Default/WithIcon/Matrix/HotIndicator)

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 238 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/Chip → Matrix\` 12 조합 렌더
- [ ] Storybook \`Common/Badge → Matrix\` 색상×상태 매트릭스 렌더

## Notes

- Chip icon은 이모지/문자열 뿐 아니라 커스텀 React 노드 슬롯
- 페이지 컴포넌트의 실제 카테고리 필터·HOT 표시 교체는 **P8**에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)