### PR TITLE
feat(dropdown): Figma 신규 사양 반영 Dropdown 신설

### DIFF
--- a/apps/web/src/components/common/Dropdown.stories.tsx
+++ b/apps/web/src/components/common/Dropdown.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { useState } from 'react'
+import { Dropdown, type DropdownOption } from './Dropdown'
+
+const options: DropdownOption[] = [
+  { label: 'option1', value: '1' },
+  { label: 'option2', value: '2' },
+  { label: 'option3', value: '3' },
+  { label: 'option4', value: '4' },
+]
+
+const meta = {
+  title: 'Common/Dropdown',
+  component: Dropdown,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Figma `6280:9019` 기반. state: default / focus (자동 :hover:border) / active(open) / disabled / error. 커스텀 UI로 옵션 메뉴 렌더. outside click/Escape로 닫힘. 접근성: role=combobox, aria-expanded, aria-controls.',
+      },
+    },
+  },
+  args: {
+    label: '필드레이블',
+    placeholder: '텍스트',
+    options,
+  },
+} satisfies Meta<typeof Dropdown>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Interactive: Story = {
+  render: (args) => {
+    const [value, setValue] = useState<string>()
+    return <Dropdown {...args} value={value} onValueChange={setValue} />
+  },
+}
+
+export const Filled: Story = {
+  args: { options },
+  render: (args) => <Dropdown {...args} value="2" onValueChange={() => {}} />,
+}
+
+export const Disabled: Story = {
+  args: { disabled: true },
+}
+
+export const ErrorState: Story = {
+  args: {
+    error: true,
+    errorMessage: '선택이 필요합니다',
+  },
+}
+
+/** 5 states 매트릭스 (open 상태는 Interactive에서 확인) */
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-6 p-4">
+      <Dropdown
+        label="default"
+        placeholder="텍스트"
+        options={options}
+      />
+      <Dropdown
+        label="filled"
+        options={options}
+        value="1"
+        onValueChange={() => {}}
+      />
+      <Dropdown
+        label="disabled"
+        placeholder="선택 불가"
+        options={options}
+        disabled
+      />
+      <Dropdown
+        label="error"
+        placeholder="텍스트"
+        options={options}
+        error
+        errorMessage="선택이 필요합니다"
+      />
+    </div>
+  ),
+}

--- a/apps/web/src/components/common/Dropdown.tsx
+++ b/apps/web/src/components/common/Dropdown.tsx
@@ -1,0 +1,6 @@
+export {
+  Dropdown,
+  dropdownBoxVariants,
+  type DropdownProps,
+  type DropdownOption,
+} from '@/components/ui/dropdown'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export * from './Dropdown'

--- a/apps/web/src/components/ui/dropdown.tsx
+++ b/apps/web/src/components/ui/dropdown.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+/* eslint-disable react/prop-types */
+
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+const dropdownBoxVariants = cva(
+  'flex w-full items-center justify-between gap-2 rounded-xl border px-4 py-2 transition-colors typo-label-03 text-left',
+  {
+    variants: {
+      state: {
+        default:
+          'bg-card border-brand-gray-75 text-brand-gray-100 hover:border-brand-violet-200',
+        active: 'bg-card border-brand-violet-200 text-brand-gray-100',
+        disabled:
+          'bg-brand-gray-50 border-transparent text-brand-gray-75 cursor-not-allowed',
+        error: 'bg-card border-destructive text-brand-gray-300',
+      },
+    },
+    defaultVariants: { state: 'default' },
+  },
+)
+
+const supportVariants = cva('typo-body-c-03 flex items-center gap-1', {
+  variants: {
+    state: {
+      default: 'text-brand-gray-100',
+      active: 'text-brand-gray-100',
+      disabled: 'text-brand-gray-100',
+      error: 'text-destructive',
+    },
+  },
+  defaultVariants: { state: 'default' },
+})
+
+type DropdownState = NonNullable<
+  VariantProps<typeof dropdownBoxVariants>['state']
+>
+
+export interface DropdownOption<T extends string = string> {
+  label: React.ReactNode
+  value: T
+}
+
+export interface DropdownProps<T extends string = string> {
+  label?: React.ReactNode
+  placeholder?: string
+  options: DropdownOption<T>[]
+  value?: T
+  onValueChange?: (value: T) => void
+  disabled?: boolean
+  error?: boolean
+  errorMessage?: React.ReactNode
+  className?: string
+  id?: string
+}
+
+const generateId = () => `dropdown-${Math.random().toString(36).slice(2, 10)}`
+
+function Dropdown<T extends string = string>({
+  label,
+  placeholder = '선택',
+  options,
+  value,
+  onValueChange,
+  disabled = false,
+  error = false,
+  errorMessage,
+  className,
+  id: idProp,
+}: DropdownProps<T>) {
+  const reactId = React.useId()
+  const id = idProp ?? `${reactId}-${generateId()}`
+  const menuId = `${id}-menu`
+  const errorId = errorMessage ? `${id}-err` : undefined
+
+  const [open, setOpen] = React.useState(false)
+  const rootRef = React.useRef<HTMLDivElement>(null)
+
+  const state: DropdownState = disabled
+    ? 'disabled'
+    : error
+      ? 'error'
+      : open
+        ? 'active'
+        : 'default'
+
+  const selected = options.find((o) => o.value === value)
+  const displayText = selected ? selected.label : placeholder
+
+  React.useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', handleClick)
+    document.addEventListener('keydown', handleKey)
+    return () => {
+      document.removeEventListener('mousedown', handleClick)
+      document.removeEventListener('keydown', handleKey)
+    }
+  }, [open])
+
+  const handleSelect = (v: T) => {
+    onValueChange?.(v)
+    setOpen(false)
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn('flex w-full flex-col gap-2', className)}
+    >
+      {label && (
+        <label htmlFor={id} className="typo-title-02 text-foreground">
+          {label}
+        </label>
+      )}
+      <div className="relative flex flex-col gap-1">
+        <button
+          id={id}
+          type="button"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-controls={menuId}
+          aria-invalid={error || undefined}
+          aria-describedby={errorId}
+          disabled={disabled}
+          onClick={() => setOpen((v) => !v)}
+          className={dropdownBoxVariants({ state })}
+        >
+          <span className="flex-1 truncate">{displayText}</span>
+          <ChevronIcon open={open} aria-hidden="true" />
+        </button>
+        {open && !disabled && (
+          <ul
+            id={menuId}
+            role="listbox"
+            className="absolute top-full left-0 z-50 mt-1 w-full overflow-hidden rounded-xl bg-card shadow-[0_1px_5.3px_rgba(0,0,0,0.25)]"
+          >
+            {options.map((opt) => {
+              const isSelected = opt.value === value
+              return (
+                <li key={opt.value} role="option" aria-selected={isSelected}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelect(opt.value)}
+                    className={cn(
+                      'flex w-full items-center gap-2.5 px-4 py-1 typo-label-03 text-left transition-colors hover:bg-brand-violet-50',
+                      isSelected ? 'text-primary' : 'text-brand-gray-400',
+                    )}
+                  >
+                    {opt.label}
+                  </button>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        {error && errorMessage && (
+          <span id={errorId} className={supportVariants({ state })}>
+            <ErrorIcon aria-hidden="true" />
+            {errorMessage}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const ChevronIcon = ({
+  open,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { open: boolean }) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    className={cn('shrink-0 transition-transform', open && 'rotate-180')}
+    {...props}
+  >
+    <path
+      d="M6 9l6 6 6-6"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const ErrorIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    className="shrink-0 text-destructive"
+    {...props}
+  >
+    <circle cx="9" cy="9" r="7.5" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M9 5v4.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <circle cx="9" cy="12.5" r="0.9" fill="currentColor" />
+  </svg>
+)
+
+export { Dropdown, dropdownBoxVariants }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P5** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

Figma [\`6280:9019\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6280-9019) "드롭다운" 기반.

### 상태 매핑

Figma 5 states → 코드 4 state (focus는 CSS hover):

| Figma | 코드 처리 |
|---|---|
| default | \`state="default"\` (\`hover:border-brand-violet-200\`) |
| **focus** | 자동 (\`:hover:border\` on default) |
| active(open) | \`state="active"\` (open 시 자동) |
| disabled | \`state="disabled"\` |
| error | \`state="error"\` |

### 컴포넌트 스펙

- **wrapper**: rounded-xl, padding 4px 16px, border 1px
- **label**: \`typo-title-02\` (Title-02 · 17/600)
- **input display text**: \`typo-label-03\` (Label-02 · 14/500)
- **placeholder**: G100
- **chevron icon**: 24×24 · open 시 rotate-180
- **menu**: absolute, shadow \`0 1px 5.3px rgba(0,0,0,0.25)\`, rounded-xl
- **option**: hover bg V50, selected text primary
- **error**: border R300, error icon + red support text

### 인터랙션

- outside click → close
- Escape 키 → close
- option 클릭 → onValueChange + close

### 접근성

- \`role="combobox"\`, \`aria-expanded\`, \`aria-controls\`, \`aria-haspopup="listbox"\`
- 옵션 목록: \`role="listbox"\`, 각 항목 \`role="option"\` + \`aria-selected\`
- error 시: \`aria-invalid\`, \`aria-describedby\`

### API

\`\`\`tsx
<Dropdown
  label="필드레이블"
  placeholder="선택"
  options={[{ label: '옵션1', value: '1' }, ...]}
  value={value}
  onValueChange={setValue}
  error={hasError}
  errorMessage="선택이 필요합니다"
/>
\`\`\`

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 237 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/Dropdown → Interactive\` 클릭 시 open/close, 옵션 선택
- [ ] Storybook \`Common/Dropdown → AllStates\` 4 states 렌더

## Notes

- Native \`<select>\` 대신 커스텀 UI (Figma 사양 정확 반영)
- Radix 등 헤드리스 라이브러리 미도입 (의존성 최소화)
- 키보드 arrow-key 순회는 P8/후속에서 필요 시 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)