### PR TITLE
feat(modal,popup): Figma 팝업 사양 반영 Popup 신설 + Modal 리브랜딩

### DIFF
--- a/apps/web/src/components/common/Modal.tsx
+++ b/apps/web/src/components/common/Modal.tsx
@@ -1,0 +1,10 @@
+export {
+  Modal,
+  ModalOverlay,
+  ModalHeader,
+  ModalTitle,
+  ModalDescription,
+  ModalBody,
+  ModalFooter,
+  ModalCloseButton,
+} from '@/components/ui/modal'

--- a/apps/web/src/components/common/Popup.stories.tsx
+++ b/apps/web/src/components/common/Popup.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { useState } from 'react'
+import { Popup } from './Popup'
+
+const meta = {
+  title: 'Common/Popup',
+  component: Popup,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Figma `6358:8151` "팝업" 기반. variant: confirm(투버튼) / alert(원버튼) / error(원버튼 · ghost purple). 컨테이너 radius 20 · bg white · Title-02 center · Body B-01 center.',
+      },
+    },
+  },
+  args: {
+    open: true,
+    title: '라벨텍스트',
+    description: '서브 텍스트',
+    onClose: () => {},
+  },
+  argTypes: {
+    variant: { control: 'radio', options: ['confirm', 'alert', 'error'] },
+  },
+} satisfies Meta<typeof Popup>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Confirm: Story = {
+  args: { variant: 'confirm', confirmLabel: '선택지 B', cancelLabel: '선택지 A' },
+}
+
+export const Alert: Story = {
+  args: { variant: 'alert', confirmLabel: '확인' },
+}
+
+export const ErrorVariant: Story = {
+  args: {
+    variant: 'error',
+    title: '오류가 발생했습니다',
+    description: '잠시 후 다시 시도해주세요',
+    confirmLabel: '확인',
+  },
+}
+
+export const WithoutDescription: Story = {
+  args: { description: undefined },
+}
+
+/** 실제 인터랙션 시연 (open/close) */
+export const Interactive: Story = {
+  args: undefined as never,
+  render: () => {
+    const [open, setOpen] = useState(true)
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="typo-label-03 rounded-lg bg-primary px-3 py-2 text-primary-foreground"
+        >
+          팝업 열기
+        </button>
+        <Popup
+          open={open}
+          onClose={() => setOpen(false)}
+          variant="confirm"
+          title="정말 삭제하시겠어요?"
+          description="이 작업은 되돌릴 수 없어요"
+          confirmLabel="삭제"
+          onConfirm={() => alert('삭제 실행')}
+          cancelLabel="취소"
+        />
+      </>
+    )
+  },
+}

--- a/apps/web/src/components/common/Popup.tsx
+++ b/apps/web/src/components/common/Popup.tsx
@@ -1,0 +1,1 @@
+export { Popup, type PopupProps, type PopupVariant } from '@/components/ui/popup'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,2 @@
+export * from './Modal'
+export * from './Popup'

--- a/apps/web/src/components/ui/modal.tsx
+++ b/apps/web/src/components/ui/modal.tsx
@@ -12,7 +12,7 @@ const ModalOverlay = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center',
+      'fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm px-5',
       className,
     )}
     onClick={(e) => {
@@ -32,36 +32,36 @@ const ModalHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      'flex items-start justify-between p-6 border-border',
-      className,
-    )}
+    className={cn('flex items-start justify-between px-5 pt-5', className)}
     {...props}
   />
 ))
 ModalHeader.displayName = 'ModalHeader'
 
-// Title: 모달의 제목 텍스트
+// Title: 모달의 제목 텍스트 (Figma Title-02)
 const ModalTitle = React.forwardRef<
   HTMLHeadingElement,
   React.HTMLAttributes<HTMLHeadingElement>
 >(({ className, ...props }, ref) => (
   <h2
     ref={ref}
-    className={cn('text-lg font-semibold text-foreground text-left', className)}
+    className={cn('typo-title-02 text-foreground text-center flex-1', className)}
     {...props}
   />
 ))
 ModalTitle.displayName = 'ModalTitle'
 
-// Description: 부제나 설명 텍스트
+// Description: 부제나 설명 텍스트 (Figma Body B-01)
 const ModalDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn('text-sm text-muted-foreground mt-1', className)}
+    className={cn(
+      'typo-body-b-01 text-brand-gray-100 text-center mt-3',
+      className,
+    )}
     {...props}
   />
 ))
@@ -74,20 +74,20 @@ const ModalBody = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('p-6 space-y-4 text-left', className)}
+    className={cn('px-5 py-4 text-left', className)}
     {...props}
   />
 ))
 ModalBody.displayName = 'ModalBody'
 
-// Footer: 확인/취소 버튼 영역
+// Footer: 확인/취소 버튼 영역 (Figma 팝업 규격: gap 12)
 const ModalFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex justify-end gap-3 p-6 pt-0', className)}
+    className={cn('flex justify-stretch gap-3 px-5 pb-6 [&>*]:flex-1', className)}
     {...props}
   />
 ))
@@ -97,54 +97,38 @@ ModalFooter.displayName = 'ModalFooter'
 const ModalCloseButton = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ className, ...props }, ref) => (
+>(({ className, type = 'button', ...props }, ref) => (
   <button
     ref={ref}
+    type={type}
     className={cn(
-      'text-muted-foreground hover:text-foreground transition-colors',
+      'text-brand-gray-100 hover:text-foreground transition-colors',
       className,
     )}
     {...props}
   >
-    <X className="w-4 h-4" />
+    <X className="w-5 h-5" />
   </button>
 ))
 ModalCloseButton.displayName = 'ModalCloseButton'
 
-// Main Modal Container
+// Main Modal Container (Figma 팝업 컨테이너: radius 20, bg white, max-w 352)
 const Modal = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
+    role="dialog"
+    aria-modal="true"
     className={cn(
-      'z-50 w-full max-w-md rounded-xl bg-background text-foreground shadow-lg animate-in fade-in-50 zoom-in-90',
+      'z-50 w-full max-w-[352px] rounded-[20px] bg-card text-foreground shadow-lg animate-in fade-in-50 zoom-in-90',
       className,
     )}
     {...props}
   />
 ))
 Modal.displayName = 'Modal'
-
-// Example Composition
-// <ModalOverlay>
-//   <Modal>
-//     <ModalHeader>
-//       <ModalTitle>삭제하시겠습니까?</ModalTitle>
-//       <ModalCloseButton onClick={closeModal} />
-//     </ModalHeader>
-//     <ModalBody>
-//       <ModalDescription>
-//         이 작업은 되돌릴 수 없습니다. 정말 삭제하시겠습니까?
-//       </ModalDescription>
-//     </ModalBody>
-//     <ModalFooter>
-//       <Button variant="secondary" onClick={closeModal}>취소</Button>
-//       <Button variant="destructive" onClick={confirmDelete}>삭제</Button>
-//     </ModalFooter>
-//   </Modal>
-// </ModalOverlay>
 
 export {
   Modal,

--- a/apps/web/src/components/ui/popup.tsx
+++ b/apps/web/src/components/ui/popup.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+/* eslint-disable react/prop-types */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+import { ModalOverlay } from './modal'
+
+export type PopupVariant = 'confirm' | 'alert' | 'error'
+
+export interface PopupProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * confirm = 두 버튼 (secondary + primary)
+   * alert   = 원 버튼 (primary)
+   * error   = 원 버튼 (ghost purple)
+   */
+  variant?: PopupVariant
+  title: React.ReactNode
+  description?: React.ReactNode
+  confirmLabel?: React.ReactNode
+  onConfirm?: () => void
+  cancelLabel?: React.ReactNode
+  onCancel?: () => void
+  className?: string
+}
+
+const buttonBase =
+  'inline-flex h-12 flex-1 items-center justify-center rounded-xl px-3 typo-label-03 transition-colors disabled:opacity-50 disabled:cursor-not-allowed'
+
+const Popup = ({
+  open,
+  onClose,
+  variant = 'confirm',
+  title,
+  description,
+  confirmLabel = '확인',
+  onConfirm,
+  cancelLabel = '취소',
+  onCancel,
+  className,
+}: PopupProps) => {
+  if (!open) return null
+
+  const handleCancel = () => {
+    onCancel?.()
+    onClose()
+  }
+
+  const handleConfirm = () => {
+    onConfirm?.()
+    onClose()
+  }
+
+  const confirmClasses =
+    variant === 'error'
+      ? 'bg-brand-violet-50 text-primary hover:bg-brand-violet-75'
+      : 'bg-primary text-primary-foreground hover:bg-brand-violet-400'
+
+  return (
+    <ModalOverlay onClose={onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="popup-title"
+        aria-describedby={description ? 'popup-desc' : undefined}
+        className={cn(
+          'flex w-full max-w-[352px] flex-col gap-6 rounded-[20px] bg-card px-5 pt-10 pb-6 shadow-lg animate-in fade-in-50 zoom-in-90',
+          className,
+        )}
+      >
+        <div className="flex flex-col gap-3">
+          <h2
+            id="popup-title"
+            className="typo-title-02 text-center text-foreground"
+          >
+            {title}
+          </h2>
+          {description && (
+            <p
+              id="popup-desc"
+              className="typo-body-b-01 text-center text-brand-gray-100"
+            >
+              {description}
+            </p>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {variant === 'confirm' && (
+            <button
+              type="button"
+              onClick={handleCancel}
+              className={cn(
+                buttonBase,
+                'bg-brand-gray-50 text-primary hover:bg-brand-gray-75',
+              )}
+            >
+              {cancelLabel}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={handleConfirm}
+            className={cn(buttonBase, confirmClasses)}
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </ModalOverlay>
+  )
+}
+
+export { Popup }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P6** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

Figma [\`6358:8151\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6358-8151) "팝업" 기반.

### 접근 방식

기존 modal API가 여러 곳(\`ui/modal/*\`, \`pages/my/titles/*\`, \`poll/Comment/*\`, \`onboarding/mbtiBottomSheet\`)에서 이미 사용 중이라 조립식 API 유지 + 스타일만 리브랜딩. Figma 신규 사양은 심플 declarative API로 별도의 \`Popup\` 컴포넌트에.

### \`ui/modal.tsx\` (리브랜딩)

| 요소 | 기존 | 신규 |
|---|---|---|
| container | \`rounded-xl bg-background max-w-md\` | \`rounded-[20px] bg-card max-w-[352px]\` |
| Title | \`text-lg font-semibold\` | \`typo-title-02 text-center\` |
| Description | \`text-sm text-muted-foreground\` | \`typo-body-b-01 text-brand-gray-100 text-center\` |
| Footer | \`justify-end gap-3 p-6\` | \`gap-3 px-5 pb-6 [&>*]:flex-1\` (Figma 팝업 규격) |
| Dialog | — | \`role=dialog\`, \`aria-modal\` 추가 |

### \`ui/popup.tsx\` (신규 · declarative API)

3 variants:

- **confirm** (투버튼) — secondary(gray) + primary(V300)
- **alert** (원버튼) — primary(V300)
- **error** (원버튼) — ghost purple (V50 배경 · V300 텍스트)

### API

\`\`\`tsx
<Popup
  open={open}
  onClose={close}
  variant="confirm"
  title="정말 삭제하시겠어요?"
  description="이 작업은 되돌릴 수 없어요"
  confirmLabel="삭제"
  cancelLabel="취소"
  onConfirm={fn}
  onCancel={fn}
/>
\`\`\`

접근성: \`role=dialog\`, \`aria-modal\`, \`aria-labelledby\`, \`aria-describedby\`.

### common/ 재수출 · Storybook

- \`common/Modal.tsx\` (기존 조립식 API)
- \`common/Popup.tsx\` (신규 심플 API)
- \`common/index.ts\` barrel
- Storybook \`Common/Popup\` (Confirm/Alert/Error/WithoutDescription/Interactive)

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 237 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/Popup → Interactive\` open/close 및 클릭 동작
- [ ] 기존 modal 사용처(\`titlePurchaseModal\` 등) 리브랜딩된 스타일 확인

## Notes

- 기존 \`ui/modal/confirmModal\`, \`deleteConfirmModal\`, \`exitConfirmModal\`, \`loginRequiredModal\`은 그대로 호환 (조립식 API 유지). Popup으로 실제 이관은 **P8** 마이그레이션 스코프.
- P1 Button의 \`destructive\` variant는 여전히 존재. Popup의 error variant는 별개 (ghost purple).

🤖 Generated with [Claude Code](https://claude.com/claude-code)