### PR TITLE
feat(vote-card): Figma 신규 사양 반영 VoteCard primitives 신설

### DIFF
--- a/apps/web/src/components/common/VoteCard.stories.tsx
+++ b/apps/web/src/components/common/VoteCard.stories.tsx
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from '@storybook/nextjs'
+import { useState } from 'react'
+import {
+  VoteCard,
+  VoteCardAuthor,
+  VoteCardAvatar,
+  VoteCardHeader,
+  VoteCardMeta,
+  VoteCardOption,
+  VoteCardOptions,
+  VoteCardStats,
+  VoteCardTitle,
+  VoteCardVS,
+} from './VoteCard'
+
+const meta = {
+  title: 'Common/VoteCard',
+  component: VoteCard,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Figma `6315:7668` + `6328:8114` 기반. 조립식 primitives. 홈화면 variant는 chip+시간, 밸런스탭 variant는 아바타+닉네임+시간. 옵션은 A/VS/B 세로.',
+      },
+    },
+  },
+} satisfies Meta<typeof VoteCard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** 홈화면 variant — chip + 시간 헤더 */
+export const HomeVariant: Story = {
+  render: () => (
+    <VoteCard>
+      <VoteCardHeader>
+        <span className="typo-body-c-03 rounded-xl border border-brand-violet-100 bg-card px-2 py-1 text-primary">
+          🩷 연애
+        </span>
+        <VoteCardMeta>아니오챤 님이 8분 전에 올렸어요</VoteCardMeta>
+      </VoteCardHeader>
+      <VoteCardTitle>뭐가 더 사랑일까?</VoteCardTitle>
+      <VoteCardOptions>
+        <VoteCardOption>손 시려우니까 얼른 들어가라는 애인</VoteCardOption>
+        <VoteCardOption>손 시려우니까 조금만 더 잡고 있자는 애인</VoteCardOption>
+        <VoteCardVS />
+      </VoteCardOptions>
+      <VoteCardStats participants={30} commentCount={12} likeCount={12} />
+    </VoteCard>
+  ),
+}
+
+/** 밸런스탭 variant — 아바타 + 닉네임 헤더 */
+export const BalanceVariant: Story = {
+  render: () => (
+    <VoteCard>
+      <VoteCardHeader>
+        <VoteCardAvatar />
+        <div className="flex items-center gap-2">
+          <VoteCardAuthor>닉네임최대16글자</VoteCardAuthor>
+          <VoteCardMeta>n분 전</VoteCardMeta>
+        </div>
+      </VoteCardHeader>
+      <VoteCardTitle>뭐가 더 사랑일까?</VoteCardTitle>
+      <VoteCardOptions>
+        <VoteCardOption>손 시려우니까 얼른 들어가라는 애인</VoteCardOption>
+        <VoteCardOption>손 시려우니까 조금만 더 잡고 있자는 애인</VoteCardOption>
+        <VoteCardVS />
+      </VoteCardOptions>
+      <VoteCardStats participants={30} commentCount={12} likeCount={12} />
+    </VoteCard>
+  ),
+}
+
+/** 투표 후: 선택 상태 강조 */
+export const Voted: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<'A' | 'B'>('A')
+    return (
+      <VoteCard>
+        <VoteCardHeader>
+          <VoteCardAvatar />
+          <div className="flex items-center gap-2">
+            <VoteCardAuthor>닉네임최대16글자</VoteCardAuthor>
+            <VoteCardMeta>n분 전</VoteCardMeta>
+          </div>
+        </VoteCardHeader>
+        <VoteCardTitle>뭐가 더 사랑일까?</VoteCardTitle>
+        <VoteCardOptions>
+          <VoteCardOption
+            selected={selected === 'A'}
+            onClick={() => setSelected('A')}
+          >
+            손 시려우니까 얼른 들어가라는 애인
+          </VoteCardOption>
+          <VoteCardOption
+            selected={selected === 'B'}
+            onClick={() => setSelected('B')}
+          >
+            손 시려우니까 조금만 더 잡고 있자는 애인
+          </VoteCardOption>
+          <VoteCardVS />
+        </VoteCardOptions>
+        <VoteCardStats participants={30} commentCount={12} likeCount={12} />
+      </VoteCard>
+    )
+  },
+}
+
+/** 통계 없이 미리보기용 최소 카드 */
+export const Minimal: Story = {
+  render: () => (
+    <VoteCard>
+      <VoteCardTitle>뭐가 더 사랑일까?</VoteCardTitle>
+      <VoteCardOptions>
+        <VoteCardOption>선택지 A</VoteCardOption>
+        <VoteCardOption>선택지 B</VoteCardOption>
+        <VoteCardVS />
+      </VoteCardOptions>
+    </VoteCard>
+  ),
+}

--- a/apps/web/src/components/common/VoteCard.tsx
+++ b/apps/web/src/components/common/VoteCard.tsx
@@ -1,0 +1,15 @@
+export {
+  VoteCard,
+  VoteCardHeader,
+  VoteCardAvatar,
+  VoteCardAuthor,
+  VoteCardMeta,
+  VoteCardTitle,
+  VoteCardOptions,
+  VoteCardOption,
+  VoteCardVS,
+  VoteCardStats,
+  type VoteCardAvatarProps,
+  type VoteCardOptionProps,
+  type VoteCardStatsProps,
+} from '@/components/ui/voteCard'

--- a/apps/web/src/components/common/index.ts
+++ b/apps/web/src/components/common/index.ts
@@ -1,0 +1,1 @@
+export * from './VoteCard'

--- a/apps/web/src/components/ui/voteCard.tsx
+++ b/apps/web/src/components/ui/voteCard.tsx
@@ -1,0 +1,245 @@
+/* eslint-disable react/prop-types */
+
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+/** VoteCard root — 컨테이너 (radius 20, bg white, shadow, padding 20/16) */
+const VoteCard = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'flex w-full max-w-[360px] flex-col gap-4 rounded-[20px] bg-card px-4 py-5 shadow-[0_0_4px_rgba(0,0,0,0.25)]',
+      className,
+    )}
+    {...props}
+  />
+))
+VoteCard.displayName = 'VoteCard'
+
+/** 헤더 영역 (홈: chip+시간, 밸런스: 아바타+닉네임+시간) */
+const VoteCardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('flex items-center gap-3', className)}
+    {...props}
+  />
+))
+VoteCardHeader.displayName = 'VoteCardHeader'
+
+/** 원형 프로필 아바타 (36px). Image src 없으면 회색 placeholder */
+export interface VoteCardAvatarProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  src?: string
+  alt?: string
+}
+
+const VoteCardAvatar = React.forwardRef<HTMLDivElement, VoteCardAvatarProps>(
+  ({ className, src, alt = '', ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        'h-9 w-9 shrink-0 overflow-hidden rounded-full bg-brand-gray-75',
+        className,
+      )}
+      {...props}
+    >
+      {src && (
+        <img src={src} alt={alt} className="h-full w-full object-cover" />
+      )}
+    </div>
+  ),
+)
+VoteCardAvatar.displayName = 'VoteCardAvatar'
+
+/** 닉네임 (Label-02 · 14/500) */
+const VoteCardAuthor = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    className={cn('typo-label-03 text-foreground', className)}
+    {...props}
+  />
+))
+VoteCardAuthor.displayName = 'VoteCardAuthor'
+
+/** 부가 메타 텍스트 (시간·업로더 안내 · Label-03) */
+const VoteCardMeta = React.forwardRef<
+  HTMLSpanElement,
+  React.HTMLAttributes<HTMLSpanElement>
+>(({ className, ...props }, ref) => (
+  <span
+    ref={ref}
+    className={cn('typo-body-c-03 text-brand-gray-100', className)}
+    {...props}
+  />
+))
+VoteCardMeta.displayName = 'VoteCardMeta'
+
+/** 질문 타이틀 (Title-02 · 17/600) */
+const VoteCardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn('typo-title-02 text-foreground', className)}
+    {...props}
+  />
+))
+VoteCardTitle.displayName = 'VoteCardTitle'
+
+/** 옵션 그룹 (A/VS/B 세로 배치) */
+const VoteCardOptions = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('relative flex flex-col gap-3', className)}
+    {...props}
+  />
+))
+VoteCardOptions.displayName = 'VoteCardOptions'
+
+/** 단일 옵션 버튼 (bg G50 · V300 텍스트 · rounded-xl · padding 10 12) */
+export interface VoteCardOptionProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  selected?: boolean
+}
+
+const VoteCardOption = React.forwardRef<HTMLButtonElement, VoteCardOptionProps>(
+  ({ className, selected, type = 'button', ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      aria-pressed={selected}
+      className={cn(
+        'flex min-h-12 items-center justify-center rounded-xl px-3 py-2.5 typo-label-03 text-center transition-colors',
+        selected
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-brand-gray-50 text-primary hover:bg-brand-violet-50',
+        className,
+      )}
+      {...props}
+    />
+  ),
+)
+VoteCardOption.displayName = 'VoteCardOption'
+
+/** VS 배지 (옵션 A/B 사이 중앙) */
+const VoteCardVS = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    aria-hidden="true"
+    className={cn(
+      'absolute left-1/2 top-1/2 flex h-9 w-9 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-card typo-title-04 text-brand-black shadow-[0_0_4px_rgba(0,0,0,0.15)]',
+      className,
+    )}
+    {...props}
+  >
+    VS
+  </div>
+))
+VoteCardVS.displayName = 'VoteCardVS'
+
+/** 하단 통계 (참여자·댓글·좋아요) */
+export interface VoteCardStatsProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  participants?: number
+  commentCount?: number
+  likeCount?: number
+}
+
+const VoteCardStats = React.forwardRef<HTMLDivElement, VoteCardStatsProps>(
+  (
+    { className, participants, commentCount, likeCount, children, ...props },
+    ref,
+  ) => (
+    <div
+      ref={ref}
+      className={cn('flex items-center justify-between', className)}
+      {...props}
+    >
+      {participants !== undefined ? (
+        <span className="typo-body-c-03 text-brand-gray-100">
+          {participants}명 참여 중
+        </span>
+      ) : (
+        <span />
+      )}
+      <div className="flex items-center gap-3">
+        {commentCount !== undefined && (
+          <VoteCardStatItem icon={<CommentIcon />} value={commentCount} />
+        )}
+        {likeCount !== undefined && (
+          <VoteCardStatItem icon={<HeartIcon />} value={likeCount} />
+        )}
+        {children}
+      </div>
+    </div>
+  ),
+)
+VoteCardStats.displayName = 'VoteCardStats'
+
+const VoteCardStatItem = ({
+  icon,
+  value,
+}: {
+  icon: React.ReactNode
+  value: React.ReactNode
+}) => (
+  <span className="flex items-center gap-1 text-brand-gray-100">
+    {icon}
+    <span className="typo-label-03">{value}</span>
+  </span>
+)
+
+const CommentIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M3 2.5A1.5 1.5 0 0 1 4.5 1h7A1.5 1.5 0 0 1 13 2.5V10a1.5 1.5 0 0 1-1.5 1.5H7l-3 3v-3H4.5A1.5 1.5 0 0 1 3 10V2.5z" />
+  </svg>
+)
+
+const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="currentColor"
+    aria-hidden="true"
+    {...props}
+  >
+    <path d="M8 14s-5-3.05-5-7a3 3 0 0 1 5-2.24A3 3 0 0 1 13 7c0 3.95-5 7-5 7z" />
+  </svg>
+)
+
+export {
+  VoteCard,
+  VoteCardHeader,
+  VoteCardAvatar,
+  VoteCardAuthor,
+  VoteCardMeta,
+  VoteCardTitle,
+  VoteCardOptions,
+  VoteCardOption,
+  VoteCardVS,
+  VoteCardStats,
+}


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P7** 실행 (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

Figma [\`6315:7668\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6315-7668) + [\`6328:8114\`](https://www.figma.com/design/bQIUgk3g44EyADlWTLxecw/Valanse_develop_mode?node-id=6328-8114) 기반.

### 조립식 primitives

기존 페이지의 \`pollCard.tsx\`는 그대로 두고, 신규 디자인은 조립식 primitives로 노출. 페이지 컴포넌트가 필요한 파트만 선택 조합.

| primitive | 역할 |
|---|---|
| \`VoteCard\` | 컨테이너 (radius 20 · bg card · shadow · padding 20/16 · max-w 360) |
| \`VoteCardHeader\` | 헤더 슬롯 (홈: chip+시간, 밸런스: 아바타+닉네임) |
| \`VoteCardAvatar\` | 원형 아바타 36px (src 없으면 G75 placeholder) |
| \`VoteCardAuthor\` | 닉네임 (typo-label-03) |
| \`VoteCardMeta\` | 부가 텍스트 (typo-body-c-03 · G100) |
| \`VoteCardTitle\` | 질문 타이틀 (typo-title-02) |
| \`VoteCardOptions\` | 옵션 그룹 (relative, VS 배지 절대 위치용) |
| \`VoteCardOption\` | 옵션 버튼 (selected prop 시 bg-primary, 그 외 bg-brand-gray-50 · text-primary) |
| \`VoteCardVS\` | 중앙 VS 원형 배지 (absolute) |
| \`VoteCardStats\` | 참여자·댓글·좋아요 통계 (내부 SVG 아이콘) |

### 접근성

- \`VoteCardOption\`에 \`aria-pressed\` (투표 후 상태)
- \`VoteCardVS\` \`aria-hidden\` (장식적 요소)
- 통계 아이콘 \`aria-hidden\`

### Storybook

\`Common/VoteCard\`:
- \`HomeVariant\` — chip + 시간 헤더
- \`BalanceVariant\` — 아바타 + 닉네임 헤더
- \`Voted\` — selected 상태 인터랙션
- \`Minimal\` — 통계 없는 최소 카드

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 237 warnings (신규 코드 hex warn 0)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] Storybook \`Common/VoteCard → Voted\` selected 클릭 인터랙션
- [ ] Storybook \`Common/VoteCard → HomeVariant\` / \`BalanceVariant\` 두 헤더 스타일 확인

## Notes

- 이미지 variant(이미지 옵션 버튼)는 이번 스코프 밖. 텍스트형만 반영. 이미지 옵션은 페이지 마이그레이션 시 추가 primitive 검토.
- 아바타 \`<img>\`는 next/image 대신 native \`<img>\` 사용 (스토리북 정적 예시용). 실제 페이지에서 next/image로 감싸는 것을 권장.
- 기존 \`pages/poll/pollCard.tsx\`는 유지. 실제 교체는 **P8**에서.

🤖 Generated with [Claude Code](https://claude.com/claude-code)