### PR TITLE
refactor(entry): 하드코딩 hex/타이포를 브랜드 토큰으로 치환

### DIFF
--- a/apps/web/src/components/pages/entry/_components/divider.tsx
+++ b/apps/web/src/components/pages/entry/_components/divider.tsx
@@ -1,9 +1,9 @@
 function Divider() {
   return (
-    <div className="flex w-full items-center gap-2 mb-4">
-      <hr className="w-full border-gray-300" />
-      <p className="text-gray-500 text-sm whitespace-nowrap">또는</p>
-      <hr className="w-full border-gray-300" />
+    <div className="mb-4 flex w-full items-center gap-2">
+      <hr className="w-full border-border" />
+      <p className="typo-body-c-03 whitespace-nowrap text-brand-gray-100">또는</p>
+      <hr className="w-full border-border" />
     </div>
   )
 }

--- a/apps/web/src/components/pages/entry/_components/kakaoLoginButton.tsx
+++ b/apps/web/src/components/pages/entry/_components/kakaoLoginButton.tsx
@@ -27,7 +27,8 @@ function KakaoLoginButton() {
     <button
       type="button"
       onClick={goKakao}
-      className="w-full max-w-xs bg-[#FEE500] text-black flex items-center justify-center gap-2 py-3 rounded-xl font-semibold shadow-sm hover:brightness-95 mb-4"
+      // 카카오 브랜드 가이드 준수: #FEE500 · 검정 텍스트. §8 예외.
+      className="mb-4 flex w-full max-w-xs items-center justify-center gap-2 rounded-xl bg-[#FEE500] py-3 typo-body-b-01 text-brand-black shadow-sm hover:brightness-95"
     >
       카카오로 로그인
     </button>

--- a/apps/web/src/components/pages/entry/entryPage.tsx
+++ b/apps/web/src/components/pages/entry/entryPage.tsx
@@ -7,9 +7,9 @@ import KakaoLoginButton from './_components/kakaoLoginButton'
 
 function EntryPage() {
   return (
-    <div className="min-h-screen bg-[#F5F5F5] flex flex-col justify-center items-center px-6 py-10 text-center">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background px-6 py-10 text-center">
       {/* 로고 영역 */}
-      <div className="flex flex-col items-center mb-6">
+      <div className="mb-6 flex flex-col items-center">
         <Image
           src="/assets/logo.svg"
           alt="Valanse Logo"
@@ -17,11 +17,12 @@ function EntryPage() {
           height={96}
           className="mb-2"
         />
-        <h1 className="text-2xl font-bold text-[#5B6B8A]">VALANSE</h1>
+        {/* TODO(design): 로고 워드마크 색은 Figma 확정 시 브랜드 토큰으로 치환 */}
+        <h1 className="typo-heading-02 text-[#5B6B8A]">VALANSE</h1>
       </div>
 
       {/* 설명 */}
-      <p className="text-sm text-gray-700 mb-12">
+      <p className="typo-body-b-02 mb-12 text-brand-gray-200">
         밸런스 게임에 진심인 사람들을 위한
         <br />
         밸런스 게임 플랫폼
@@ -30,7 +31,7 @@ function EntryPage() {
       <div className="w-full max-w-xs">
         <Suspense
           fallback={
-            <div className="w-full max-w-xs py-3 rounded-xl bg-[#FEE500]/60 text-center text-sm text-gray-600 mb-4">
+            <div className="mb-4 w-full max-w-xs rounded-xl bg-[#FEE500]/60 py-3 text-center typo-label-03 text-brand-gray-200">
               로그인 준비 중…
             </div>
           }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P8 마이그레이션 첫 도메인 (entry)** (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

3 파일의 하드코딩 hex/임의 타이포를 브랜드 토큰과 \`.typo-*\` 클래스로 치환. 시각 회귀 없음(dev 서버 확인).

### 변경 매핑

**\`entryPage.tsx\`**
| Before | After |
|---|---|
| \`bg-[#F5F5F5]\` | \`bg-background\` |
| \`text-2xl font-bold\` | \`typo-heading-02\` |
| \`text-sm text-gray-700\` (설명) | \`typo-body-b-02 text-brand-gray-200\` |
| \`text-sm text-gray-600\` (Suspense fallback) | \`typo-label-03 text-brand-gray-200\` |
| \`text-[#5B6B8A]\` (로고 워드마크) | **유지** + TODO 주석 (Figma 확정 대기) |

**\`kakaoLoginButton.tsx\`**
| Before | After |
|---|---|
| \`font-semibold\` (임의) | \`typo-body-b-01\` |
| \`text-black\` | \`text-brand-black\` |
| \`bg-[#FEE500]\` (카카오) | **유지** + §8 예외 주석 (카카오 브랜드 가이드 준수) |

**\`divider.tsx\`**
| Before | After |
|---|---|
| \`border-gray-300\` | \`border-border\` |
| \`text-gray-500 text-sm\` | \`typo-body-c-03 text-brand-gray-100\` |

### 유지 항목 (의도적)

- **카카오 \`#FEE500\`** — 외부 브랜드 가이드 필수 표준. AGENTS.md §8 예외.
- **로고 \`#5B6B8A\`** — Figma에서 로고 워드마크 색이 확정되지 않아 유지 + TODO 주석.

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 235 warnings (entry 하드코딩 해소로 warn 감소)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [x] dev 서버 시각 검증 — \`/entry\` 렌더 회귀 없음
- [ ] 다른 뷰포트(모바일/데스크톱) 확인

## Notes

- Entry 도메인은 auth 없이 접근 가능해 P8 마이그레이션 청사진용으로 선택.
- 다음 도메인 후보: \`main\` (홈, 여러 서브섹션 포함) 또는 \`balanse\` (Chip 컴포넌트 실제 적용 좋음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)