### PR TITLE
refactor(main): 하드코딩 hex/타이포를 브랜드 토큰으로 치환

### DIFF
--- a/apps/web/src/components/pages/main/bestVoteArea.tsx
+++ b/apps/web/src/components/pages/main/bestVoteArea.tsx
@@ -33,25 +33,26 @@ function BestVoteArea() {
   }, [])
 
   return (
-    <div className="flex flex-col items-center bg-[#839db7] rounded-bl-2xl rounded-br-2xl w-screen px-6 pb-5 min-h-[500px]">
+    // TODO(design): 배경색 #839db7은 브랜드 blue-gray 팔레트 확정 후 치환
+    <div className="flex min-h-[500px] w-screen flex-col items-center rounded-b-2xl bg-[#839db7] px-6 pb-5">
       {isLoading ? (
-        <div className="flex flex-col items-center justify-center w-full pt-[98px] flex-1">
+        <div className="flex w-full flex-1 flex-col items-center justify-center pt-[98px]">
           <InlineLoading />
         </div>
       ) : (
         <>
-          <div className="flex flex-col items-center pt-[98px] leading-none min-h-[150px]">
+          <div className="flex min-h-[150px] flex-col items-center pt-[98px] leading-none">
             <Image src="/fire.svg" alt="fire" width={40} height={40} />
-            <div className="pt-4 text-white text-3xl font-bold">
+            <div className="typo-heading-01 pt-4 text-primary-foreground">
               오늘의 핫이슈
             </div>
-            <div className="pt-1 text-white text-xs font-normal">
+            <div className="typo-body-c-03 pt-1 text-primary-foreground">
               24시간 이후 투표 종료
             </div>
-            <div className="pt-4 text-white text-lg font-bold">
+            <div className="typo-heading-04 pt-4 text-primary-foreground">
               {voteData?.totalParticipants.toLocaleString()}명 참여
             </div>
-            <div className="pt-4 text-white text-lg font-bold line-clamp-2">
+            <div className="typo-heading-04 line-clamp-2 pt-4 text-primary-foreground">
               [ {voteData?.title} ]
             </div>
           </div>

--- a/apps/web/src/components/pages/main/hotIssueSection.tsx
+++ b/apps/web/src/components/pages/main/hotIssueSection.tsx
@@ -13,29 +13,30 @@ function HotIssueSection() {
   const [selectedOption, setSelectedOption] = useState<string | null>(null)
 
   return (
-    <div className="bg-[#839DB7] px-6 pb-6 rounded-b-[2rem]">
+    // TODO(design): 배경색 #839DB7은 브랜드 blue-gray 팔레트 확정 후 치환
+    <div className="rounded-b-[2rem] bg-[#839DB7] px-6 pb-6">
       {/* 투표 정보 */}
-      <div className="flex flex-col items-center pt-12">
+      <div className="flex flex-col items-center pt-12 text-primary-foreground">
         <Image src="/fire.svg" alt="fire" width={40} height={40} />
-        <div className="text-2xl font-bold pt-4">오늘의 핫이슈</div>
-        <div className="text-sm pt-1">24시간 이후 투표 종료</div>
-        <div className="text-md font-semibold pt-4">1,234명 참여</div>
+        <div className="typo-heading-02 pt-4">오늘의 핫이슈</div>
+        <div className="typo-body-c-02 pt-1">24시간 이후 투표 종료</div>
+        <div className="typo-title-03 pt-4">1,234명 참여</div>
       </div>
 
       {/* 선택지 */}
-      <div className="grid grid-cols-2 gap-2 w-full max-w-md pt-5">
+      <div className="grid w-full max-w-md grid-cols-2 gap-2 pt-5">
         {options.map((label, i) => (
           <button
             key={label}
-            className={`w-45 h-[9.5rem] rounded-lg border shadow-sm px-7 py-6 ${
+            className={`h-[9.5rem] w-45 rounded-lg border px-7 py-6 shadow-sm ${
               selectedOption === label
-                ? 'bg-black text-white'
-                : 'bg-white text-gray-800'
+                ? 'bg-brand-black text-primary-foreground'
+                : 'bg-card text-foreground'
             }`}
             onClick={() => setSelectedOption(label)}
           >
-            <div className="font-bold text-lg mb-1">{label}</div>
-            <div className="text-sm">{optionTexts[i]}</div>
+            <div className="typo-heading-04 mb-1">{label}</div>
+            <div className="typo-body-c-02">{optionTexts[i]}</div>
           </button>
         ))}
       </div>

--- a/apps/web/src/components/pages/main/mainPage.tsx
+++ b/apps/web/src/components/pages/main/mainPage.tsx
@@ -31,36 +31,38 @@ const MainPage = () => {
   }
 
   return (
-    <div className="flex flex-col items-center min-h-screen bg-[#F0F0F0] px-4 pb-24">
+    <div className="flex min-h-screen flex-col items-center bg-background px-4 pb-24">
       <BestVoteArea />
 
-      <div className="flex flex-col items-center w-full gap-10 pt-8">
+      <div className="flex w-full flex-col items-center gap-10 pt-8">
         {/* 밸런스 게임 만들기 */}
         <Link
           href="/create"
-          className="flex items-center justify-between w-full h-[120px] pl-5 pr-4 py-3 bg-white rounded-lg text-2xl font-bold"
+          className="typo-heading-02 flex h-[120px] w-full items-center justify-between rounded-lg bg-card py-3 pl-5 pr-4 text-foreground"
         >
           밸런스 게임 만들기
+          {/* TODO(P8): PR #129 머지 후 /icons/nav/create.svg로 갱신, 또는 CreateIcon 컴포넌트로 교체 */}
           <Image src="/create.svg" alt="create" width={28} height={28} />
         </Link>
 
         {/* 카테고리 */}
-        <div className="flex justify-around w-full gap-2">
+        <div className="flex w-full justify-around gap-2">
           {categories.map((c) => (
             <Link
               href={`/balanse?category=${c.param}`}
               key={c.label}
-              className="flex flex-col items-center w-full p-4 pt-7 pb-5 rounded-lg bg-white"
+              className="flex w-full flex-col items-center rounded-lg bg-card p-4 pb-5 pt-7"
             >
               <Image src={c.icon} alt={c.label} width={48} height={48} />
-              <div className="text-md mt-1 font-semibold">{c.label}</div>
+              <div className="typo-title-04 mt-1 text-foreground">{c.label}</div>
             </Link>
           ))}
         </div>
 
+        {/* TODO(design): "New 전체보기" 강조색 text-[#f27f23]은 브랜드 오렌지 팔레트 확정 후 치환 */}
         <Link
           href="/balanse"
-          className="flex items-center  w-full h-[120px] bg-white rounded-lg font-bold pl-4 text-2xl text-[#f27f23]"
+          className="typo-heading-02 flex h-[120px] w-full items-center rounded-lg bg-card pl-4 text-[#f27f23]"
         >
           New 전체보기
         </Link>

--- a/apps/web/src/components/pages/main/voteOptionGrid.tsx
+++ b/apps/web/src/components/pages/main/voteOptionGrid.tsx
@@ -15,6 +15,8 @@ interface VoteOptionGridProps {
 export default function VoteOptionGrid({ options }: VoteOptionGridProps) {
   if (!options || options.length === 0) return null
 
+  // TODO(design): 옵션 A/B 강조색 (#5F81A3 blue, #F27F34 orange)은
+  // 브랜드 팔레트에 대응 색이 없음. Figma 확정 후 브랜드 토큰으로 치환.
   const getBorderColor = (index: number) => {
     const colors = ['#5F81A3', '#F27F34']
 
@@ -48,7 +50,7 @@ export default function VoteOptionGrid({ options }: VoteOptionGridProps) {
 
   return (
     <div
-      className={`grid ${getGridColsClass(options.length)} gap-2 w-full pt-4 min-h-[164px]`}
+      className={`grid ${getGridColsClass(options.length)} min-h-[164px] w-full gap-2 pt-4`}
     >
       {options.map((option, index) => {
         const borderColor = getBorderColor(index)
@@ -56,13 +58,13 @@ export default function VoteOptionGrid({ options }: VoteOptionGridProps) {
         return (
           <div
             key={option.optionId}
-            className={`flex flex-col items-center gap-5 w-full h-full p-4 py-6 rounded-lg bg-white border`}
+            className="flex h-full w-full flex-col items-center gap-5 rounded-lg border bg-card p-4 py-6"
             style={{ borderColor }}
           >
-            <div className="font-bold text-2xl" style={{ color: textColor }}>
+            <div className="typo-heading-02" style={{ color: textColor }}>
               {optionLabel[index] ?? '?'}
             </div>
-            <div className="text-sm text-center leading-tight">
+            <div className="typo-body-c-02 text-center text-foreground leading-tight">
               {option.content}
             </div>
           </div>


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P8 두 번째 도메인 (main)** (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

홈 페이지의 4 파일 하드코딩 hex/임의 타이포를 브랜드 토큰과 \`.typo-*\` 클래스로 치환.

### 변경 파일

| 파일 | 요약 |
|---|---|
| \`mainPage.tsx\` | bg-[#F0F0F0]→bg-background, bg-white→bg-card, text-2xl font-bold→typo-heading-02, text-md font-semibold→typo-title-04 |
| \`bestVoteArea.tsx\` | text-white→text-primary-foreground, text-3xl/xs/lg 임의값→typo-heading-01/body-c-03/heading-04 |
| \`hotIssueSection.tsx\` | text-white→text-primary-foreground, bg-black→bg-brand-black, bg-white→bg-card, text-gray-800→text-foreground, 임의 타이포→typo-* |
| \`voteOptionGrid.tsx\` | bg-white→bg-card, 임의 타이포→typo-* |

### 유지 항목 (TODO 주석)

| 위치 | hex | 이유 |
|---|---|---|
| \`mainPage\` "New 전체보기" | \`#f27f23\` | 브랜드 오렌지 팔레트 미확정 |
| \`bestVoteArea\` 배경 | \`#839db7\` | 브랜드 blue-gray 팔레트 미확정 |
| \`hotIssueSection\` 배경 | \`#839DB7\` | 동일 |
| \`voteOptionGrid\` 옵션 A/B 강조색 | \`#5F81A3\`, \`#F27F34\` | Figma에 대응 색 없음 |

Figma 디자인시스템에 아직 orange / blue-gray가 정의되지 않아 유지 + TODO 주석. 팔레트 확정 시 후속 PR로 치환.

### 스코프 밖 (별도 정리)

- \`categorySection.tsx\`, \`gameCreateSection.tsx\` — 실제 미사용(mainPage에서 카테고리 렌더링을 직접 처리). dead-code 정리 별도 스코프.
- \`/create.svg\` 참조 — PR #129 (바텀탭)에서 \`/icons/nav/create.svg\`로 이관 예정. 이 브랜치엔 TODO 주석만.

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 235 warnings (자체 신규 hex warn 0, TODO 주석 유지)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] dev 서버 \`/main\` 시각 확인 (auth 필요)

## Notes

- \`/main\`은 (auth) 그룹 하위. 미로그인 시 리다이렉트되어 dev 서버로 직접 확인 어려움. 로그인 상태에서 시각 확인 권장.
- 다음 도메인 후보: \`balanse\` (unauth 페이지 → Chip 컴포넌트 실제 적용 좋음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)