### PR TITLE
refactor(balanse): 하드코딩 hex/타이포를 브랜드 토큰으로 치환

### DIFF
--- a/apps/web/src/components/pages/balanse/balanse-list-section/balanseList.tsx
+++ b/apps/web/src/components/pages/balanse/balanse-list-section/balanseList.tsx
@@ -18,43 +18,44 @@ export default function BalanceList({ data }: Props) {
   return (
     <Link href={`/poll/${data.id}?source=balance`} passHref legacyBehavior>
       <a className="block">
-        <Card className="rounded-xl cursor-pointer">
+        <Card className="cursor-pointer rounded-xl">
           <CardHeader className="flex flex-row items-center gap-2 pb-0">
             <div className="flex items-center gap-2">
-              <UserCircle className="text-gray-400 w-5 h-5" />
+              <UserCircle className="h-5 w-5 text-brand-gray-100" />
               {data.member_title && (
-                <span className="inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-[11px] font-medium text-white">
+                // TODO(design): 칭호 배경 #4D7298은 blue-gray 팔레트 미확정으로 TODO 유지
+                <span className="typo-body-c-03 inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-primary-foreground">
                   {data.member_title}
                 </span>
               )}
-              <span className="text-sm text-gray-600">
+              <span className="typo-body-c-02 text-brand-gray-100">
                 {data.nickname} • {data.created_at}
               </span>
             </div>
           </CardHeader>
-          <CardContent className="pt-2 pb-4">
-            <p className="font-semibold mb-2">{data.title}</p>
+          <CardContent className="pb-4 pt-2">
+            <p className="typo-title-02 mb-2 text-foreground">{data.title}</p>
             {data.content && (
-              <p className="text-sm text-gray-600 mb-3 leading-relaxed whitespace-pre-wrap">
+              <p className="typo-body-c-02 mb-3 whitespace-pre-wrap leading-relaxed text-brand-gray-100">
                 {data.content}
               </p>
             )}
-            <div className="text-sm text-gray-700 space-y-1">
+            <div className="typo-body-c-02 space-y-1 text-brand-gray-200">
               {data.options.map((opt) => (
-                <div key={opt.id} className="bg-white">
+                <div key={opt.id} className="bg-card">
                   {opt.content}
                 </div>
               ))}
             </div>
-            <div className="flex justify-between items-center mt-3 text-xs text-gray-500">
+            <div className="mt-3 flex items-center justify-between typo-body-c-03 text-brand-gray-100">
               <span>{categoryMap[data.category] ?? data.category}</span>
               <div className="flex gap-4">
                 <div className="flex items-center gap-1">
-                  <ThumbsUp className="w-4 h-4" />
+                  <ThumbsUp className="h-4 w-4" />
                   {data.total_vote_count}
                 </div>
                 <div className="flex items-center gap-1">
-                  <MessageCircle className="w-4 h-4" />
+                  <MessageCircle className="h-4 w-4" />
                   {data.total_comment_count}
                 </div>
               </div>

--- a/apps/web/src/components/pages/balanse/balansePage.tsx
+++ b/apps/web/src/components/pages/balanse/balansePage.tsx
@@ -163,16 +163,17 @@ function BalancePageContent() {
 
   if (trendingError && !trendingVote) {
     return (
-      <div className="flex flex-col min-h-screen bg-[#ffffff]">
+      <div className="flex min-h-screen flex-col bg-card">
         <Header />
         <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-16">
-          <p className="text-xl font-bold text-red-500">⚠️</p>
-          <p className="text-center text-lg font-semibold text-gray-700">
+          <p className="typo-heading-04 text-destructive">⚠️</p>
+          <p className="typo-title-02 text-center text-brand-gray-200">
             {trendingError}
           </p>
           <button
             type="button"
-            className="rounded-lg bg-[#4D7298] px-5 py-2.5 text-sm font-medium text-white"
+            // TODO(design): 배경 #4D7298은 blue-gray 팔레트 미확정으로 TODO 유지
+            className="typo-label-03 rounded-lg bg-[#4D7298] px-5 py-2.5 text-primary-foreground"
             onClick={() => setIsRefreshing(true)}
           >
             다시 시도
@@ -189,7 +190,7 @@ function BalancePageContent() {
   }
 
   return (
-    <div className="flex flex-col min-h-screen bg-[#ffffff]">
+    <div className="flex min-h-screen flex-col bg-card">
       <Header />
 
       {/* 인기 급상승 토픽 섹션 */}
@@ -199,13 +200,13 @@ function BalancePageContent() {
       </div>
 
       {/* 투표 목록 섹션 */}
-      <div className="flex items-center gap-2 px-4 mt-2">
+      <div className="mt-2 flex items-center gap-2 px-4">
         <FilterTabs
           selected={category}
           onChangeCategory={handleCategoryChange}
         />
         <select
-          className="ml-auto rounded px-2 py-1 text-sm"
+          className="typo-body-c-02 ml-auto rounded px-2 py-1 text-foreground"
           value={sort}
           onChange={(e) =>
             handleSortChange(e.target.value as 'latest' | 'popular')
@@ -218,11 +219,11 @@ function BalancePageContent() {
           ))}
         </select>
       </div>
-      <div className="px-4 mt-4 space-y-4 pb-28">
+      <div className="mt-4 space-y-4 px-4 pb-28">
         {error && (
           <div className="flex flex-col items-center justify-center py-8">
-            <p className="text-xl font-bold text-red-500 mb-2">⚠️</p>
-            <p className="text-lg font-semibold text-gray-700">{error}</p>
+            <p className="typo-heading-04 mb-2 text-destructive">⚠️</p>
+            <p className="typo-title-02 text-brand-gray-200">{error}</p>
           </div>
         )}
         {!error &&
@@ -230,18 +231,19 @@ function BalancePageContent() {
             <React.Fragment key={vote.id}>
               <BalanceList data={vote} />
               {idx !== votes.length - 1 && (
-                <div className="h-px bg-[#E5E5E5] w-full my-2" />
+                <div className="my-2 h-px w-full bg-border" />
               )}
             </React.Fragment>
           ))}
 
         {/* 무한 스크롤 로딩 인디케이터 */}
         {hasNextPage && (
-          <div ref={loadingRef} className="text-center py-4">
+          <div ref={loadingRef} className="py-4 text-center">
             {isLoadingMore && (
               <>
-                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-[#4D7298] mx-auto"></div>
-                <p className="text-sm text-gray-500 mt-2">
+                {/* TODO(design): spinner border 색 #4D7298은 blue-gray 팔레트 미확정으로 TODO 유지 */}
+                <div className="mx-auto h-6 w-6 animate-spin rounded-full border-b-2 border-[#4D7298]"></div>
+                <p className="typo-body-c-02 mt-2 text-brand-gray-100">
                   더 많은 투표를 불러오는 중...
                 </p>
               </>

--- a/apps/web/src/components/pages/balanse/filtertabs.tsx
+++ b/apps/web/src/components/pages/balanse/filtertabs.tsx
@@ -15,15 +15,17 @@ export default function FilterTabs({
   const tabs = ['전체', '음식', '연애', '기타']
 
   return (
-    <div className="flex gap-2 px-4 mt-4 overflow-x-auto">
+    <div className="mt-4 flex gap-2 overflow-x-auto px-4">
       {tabs.map((tab) => (
         <button
           key={tab}
-          className={`rounded-full px-3 py-2 text-sm font-medium transition whitespace-nowrap
+          // TODO(design): 활성 상태 색 #7A97B8은 blue-gray 팔레트 미확정으로 TODO 유지.
+          // 향후 Common/Chip primary variant로 교체 검토.
+          className={`typo-label-03 whitespace-nowrap rounded-full px-3 py-2 transition
             ${
               selected === tabMap[tab]
-                ? 'bg-[#7A97B8] text-white'
-                : 'bg-white text-[#8E8E8E] border border-[#C6C6C6]'
+                ? 'bg-[#7A97B8] text-primary-foreground'
+                : 'border border-border bg-card text-brand-gray-100'
             }
           `}
           onClick={() => onChangeCategory(tabMap[tab])}

--- a/apps/web/src/components/pages/balanse/header.tsx
+++ b/apps/web/src/components/pages/balanse/header.tsx
@@ -1,7 +1,7 @@
 export default function Header() {
   return (
-    <div className="px-4 pt-6 pb-2">
-      <h1 className="text-xl font-bold">밸런스 게임</h1>
+    <div className="px-4 pb-2 pt-6">
+      <h1 className="typo-heading-04 text-foreground">밸런스 게임</h1>
     </div>
   )
 }

--- a/apps/web/src/components/pages/balanse/trending-section/mockPollCard.tsx
+++ b/apps/web/src/components/pages/balanse/trending-section/mockPollCard.tsx
@@ -34,31 +34,32 @@ function MockPollCard({ data }: Props) {
   return (
     <>
       <div
-        className="block mx-auto p-4 mt-6 space-y-4 rounded-xl bg-[#F0F0F0] cursor-pointer"
+        className="mx-auto mt-6 block cursor-pointer space-y-4 rounded-xl bg-background p-4"
         onClick={handleClick}
       >
         <div className="flex items-center gap-2">
           {data.creatorTitle && (
-            <span className="inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-[11px] font-medium text-white">
+            // TODO(design): 칭호 배경 #4D7298은 blue-gray 팔레트 미확정으로 TODO 유지
+            <span className="typo-body-c-03 inline-flex items-center rounded-full bg-[#4D7298] px-2 py-0.5 text-primary-foreground">
               {data.creatorTitle}
             </span>
           )}
-          <span className="text-sm font-medium text-gray-700">
+          <span className="typo-label-03 text-brand-gray-200">
             {data.createdBy}
           </span>
         </div>
-        <div className="flex justify-between items-center">
-          <div className="text-base font-semibold">{data.title}</div>
+        <div className="flex items-center justify-between">
+          <div className="typo-title-02 text-foreground">{data.title}</div>
         </div>
 
         <div className="space-y-2">
           {data.options.map((option, idx) => {
             return (
               <div
-                className={`relative border rounded-md px-4 py-3 cursor-pointer transition-all ring-blue-500 bg-white`}
+                className="relative cursor-pointer rounded-md border border-border bg-card px-4 py-3 transition-all"
                 key={option.optionId}
               >
-                <div className="flex justify-between relative z-10 font-medium">
+                <div className="typo-label-03 relative z-10 flex justify-between text-foreground">
                   <span>
                     <strong>{String.fromCharCode(65 + idx)}</strong>{' '}
                     {option.content}
@@ -69,10 +70,10 @@ function MockPollCard({ data }: Props) {
           })}
         </div>
         <div className="flex justify-between">
-          <div className="text-xs text-gray-500 mb-2">
+          <div className="typo-body-c-03 mb-2 text-brand-gray-100">
             {categoryMap[data.category] ?? data.category}
           </div>
-          <div className="text-sm text-gray-400 text-right">
+          <div className="typo-body-c-02 text-right text-brand-gray-100">
             총 {data.totalParticipants}명 투표
           </div>
         </div>

--- a/apps/web/src/components/pages/balanse/trending-section/sectionHeader.tsx
+++ b/apps/web/src/components/pages/balanse/trending-section/sectionHeader.tsx
@@ -2,9 +2,10 @@ import { Flame } from 'lucide-react'
 
 export const SectionHeader = () => {
   return (
-    <div className="flex items-center gap-1 mt-2">
-      <Flame className="w-4 h-4 text-orange-500" />
-      <span className="text-md font-semibold">인기 급상승 토픽</span>
+    <div className="mt-2 flex items-center gap-1">
+      {/* TODO(design): orange 강조색은 브랜드 오렌지 팔레트 확정 후 치환 */}
+      <Flame className="h-4 w-4 text-orange-500" />
+      <span className="typo-title-03 text-foreground">인기 급상승 토픽</span>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

디자인시스템 개편 로드맵 **P8 세 번째 도메인 (balanse)** (📄 [docs/design-system-roadmap.md](../blob/develop/docs/design-system-roadmap.md)).

밸런스 목록 페이지의 6 파일 하드코딩을 토큰으로 치환.

### 변경 파일

| 파일 | 요약 |
|---|---|
| \`header.tsx\` | text-xl font-bold → typo-heading-04 |
| \`filtertabs.tsx\` | text-sm font-medium → typo-label-03, bg-white→bg-card, text-[#8E8E8E]→text-brand-gray-100, border-[#C6C6C6]→border-border |
| \`sectionHeader.tsx\` | typo-title-03 |
| \`trending-section/mockPollCard.tsx\` | bg-[#F0F0F0]→bg-background, gray 시멘틱화, 임의 타이포→typo-* |
| \`balanse-list-section/balanseList.tsx\` | 유사 패턴, UserCircle 아이콘 색 시멘틱 |
| \`balansePage.tsx\` | bg-[#ffffff]→bg-card, bg-[#E5E5E5]→bg-border, red-500→destructive |

### 유지 항목 (TODO 주석)

| 위치 | hex | 이유 |
|---|---|---|
| \`filtertabs\` 활성 배경 | \`#7A97B8\` | 브랜드 blue-gray 팔레트 미확정 |
| \`sectionHeader\` Flame 아이콘 | \`text-orange-500\` | 브랜드 오렌지 팔레트 미확정 |
| \`mockPollCard\` · \`balanseList\` 칭호 배지 | \`#4D7298\` | 브랜드 blue-gray 팔레트 미확정 |
| \`balansePage\` 재시도 버튼 배경 · spinner border | \`#4D7298\` | 동일 |

### 후속 고려

- FilterTabs는 향후 \`Common/Chip\` primary variant로 교체 검토 (별도 PR)
- 칭호 배지는 향후 \`Common/Badge\`로 교체 검토

## Test plan

- [x] \`pnpm --filter valanse-web lint\` — 0 errors · 231 warnings (235→231, 4개 감소)
- [x] \`pnpm --filter valanse-web build\` — 정상
- [ ] dev 서버 \`/balanse\` 시각 확인 (백엔드 필요)

## Notes

- Balanse 페이지는 백엔드 트렌딩 API 호출 필요. dev 환경에서 백엔드 미가용 시 로딩 상태 유지되어 시각 확인 어려움.
- 다음 도메인 후보: \`onboarding\` (텍스트 폼이라 TextField 실제 적용 좋음) 또는 \`create\` (auth 필요하지만 폼 스코프)

🤖 Generated with [Claude Code](https://claude.com/claude-code)