### PR TITLE
fix(my): my/created·voted 옵션 렌더 이슈 수정

### DIFF
--- a/apps/web/src/components/pages/my/_shared/balanseHistoryCard.tsx
+++ b/apps/web/src/components/pages/my/_shared/balanseHistoryCard.tsx
@@ -35,7 +35,7 @@ export default function BalanseHistoryCard({
         <div className="text-sm text-gray-700 space-y-1">
           {data.options.map((opt, index) => (
             <div key={index} className="text-[16px] font-[400] text-[#555555]">
-              {numberToAlphabet(index)} {opt}
+              {numberToAlphabet(index)} {opt.content}
             </div>
           ))}
         </div>

--- a/apps/web/src/types/api/votes.ts
+++ b/apps/web/src/types/api/votes.ts
@@ -7,6 +7,11 @@ export type CreateVoteData = {
   content?: string
 }
 
+export type MineVoteOption = {
+  content: string
+  imageUrl?: string | null
+}
+
 export type MineVotesResponse = {
   voteId: number
   title: string
@@ -14,5 +19,5 @@ export type MineVotesResponse = {
   category: string
   totalVoteCount: number
   createdAt: string
-  options: string[]
+  options: MineVoteOption[]
 }[]

--- a/apps/web/src/types/my/history.ts
+++ b/apps/web/src/types/my/history.ts
@@ -1,3 +1,8 @@
+export type MyVoteHistoryOption = {
+  content: string
+  imageUrl?: string | null
+}
+
 export type MyVoteHistoryItem = {
   voteId: number
   title: string
@@ -5,5 +10,5 @@ export type MyVoteHistoryItem = {
   category: string
   totalVoteCount: number
   createdAt: string
-  options: string[]
+  options: MyVoteHistoryOption[]
 }


### PR DESCRIPTION
## Summary
- `/vote/my/created`, `/vote/my/voted` 페이지 렌더 실패 수정 (dev + prod 모두 터짐)
- 백엔드에서 옵션 응답 포맷이 `string[]` → `{content, imageUrl}[]` 로 변경되면서 `BalanseHistoryCard` 가 객체를 그대로 render 해 "Objects are not valid as a React child" 발생
- 타입 정의(`MineVoteOption`, `MyVoteHistoryOption`) 추가하고 `{opt}` → `{opt.content}` 로 변경

관련: Discord #랜더링 이슈 lambda3936 제보

## Test plan
- [x] `tsc --noEmit` 통과
- [ ] 배포 후 `/vote/my/created` 접속 시 정상 렌더 확인
- [ ] `/vote/my/voted` 정상 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)