### PR TITLE
[FIX] 투표 선택지 이미지 R2 버킷 호스트 등록 (400 최적화 에러 수정)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,7 +9,11 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'img2.kakaocdn.net' },
       {
         protocol: 'https',
-        hostname: 'pub-87cd0d25fe40436d83d5fb49e513cd55.r2.dev',
+        hostname: 'pub-87cd0d25fe40436d83d5fb49e513cd55.r2.dev', // 프로필 이미지 버킷
+      },
+      {
+        protocol: 'https',
+        hostname: 'pub-1670751f540e495b8fbc46150a320d85.r2.dev', // 투표 선택지 이미지 버킷
       },
     ],
   },


### PR DESCRIPTION
## 문제
투표 선택지 이미지가 프로필과 다른 R2 버킷(`pub-1670751f…r2.dev`)에서 서빙되는데, `next.config.ts`의 `remotePatterns`에 미등록되어 next/image 최적화가 거부:
`400 Bad Request · INVALID_IMAGE_OPTIMIZE_REQUEST`

## 원인
- PR #150에서 이미지 기능은 main에 반영됐으나, 이 버킷 호스트 등록은 PR 머지 이후 푸시되어 main에 반영되지 못함
- 프로덕션(main) 배포엔 투표옵션 버킷이 여전히 미등록 상태

## 수정
`remotePatterns`에 투표 선택지 이미지 버킷 호스트 추가 (1파일, next.config.ts)

## 참고
- 빌드타임 설정이라 머지 후 재배포되어야 라이브 400이 해소됩니다
- develop에도 동일 패치 필요 (별도 반영 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)