### PR TITLE
[FIX] 투표 선택지 이미지 R2 버킷 호스트 등록 (400 최적화 에러 수정)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,7 +9,11 @@ const nextConfig: NextConfig = {
       { protocol: 'https', hostname: 'img2.kakaocdn.net' },
       {
         protocol: 'https',
-        hostname: 'pub-87cd0d25fe40436d83d5fb49e513cd55.r2.dev',
+        hostname: 'pub-87cd0d25fe40436d83d5fb49e513cd55.r2.dev', // 프로필 이미지 버킷
+      },
+      {
+        protocol: 'https',
+        hostname: 'pub-1670751f540e495b8fbc46150a320d85.r2.dev', // 투표 선택지 이미지 버킷
       },
     ],
   },


### PR DESCRIPTION
## 문제
투표 선택지 이미지가 프로필과 다른 R2 버킷(`pub-1670751f…r2.dev`)에서 서빙되는데, `next.config.ts`의 `remotePatterns`에 미등록되어 next/image 최적화가 거부: `400 · INVALID_IMAGE_OPTIMIZE_REQUEST`

## 수정
`remotePatterns`에 투표 선택지 이미지 버킷 호스트 추가 (next.config.ts 1파일)

## 참고
- main 대상 동일 수정은 #151 로 별도 진행
- 빌드타임 설정이라 머지 후 재배포되어야 라이브 400이 해소됩니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 추가 이미지 저장소의 원격 이미지를 정상적으로 표시할 수 있도록 지원했습니다.
  * 프로필 및 투표 선택지 이미지 로딩 호환성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->